### PR TITLE
Add proper command infrastructure

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,20 +1,46 @@
 #!/usr/bin/env ruby
 
 begin
+  # Fetch the absolute path of the `lib/` directory.
+  #
+  # `__FILE__` is a method on the Kernel class to return
+  # the absolute path of the file from which the method
+  # is called. Here, it returns:
+  # `bin/deploy/../../lib/`
+  #
+  # File#expand_path converts a path to an absolute path,
+  # replacing any shortcuts like `~` and `..`.
+  # Here, it converts the above string to:
+  # `/home/user/flight-deploy/lib`
   lib_dir = File.expand_path(File.join(__FILE__, '../../lib'))
+  # Add `lib_dir` to the $LOAD_PATH global variable.
+  # The $LOAD_PATH variable is a list of directories that
+  # the app can look through when you ask to load a specific
+  # file, via the File class, the `require` method, etc.
+  #
+  # Array#unshift adds elements to the start of an array.
+  # Unshifting the `lib_dir` path prioritises it over the
+  # rest of the $LOAD_PATH array when looking for a file.
   $LOAD_PATH.unshift(lib_dir)
-  ENV['BUNDLE_GEMFILE'] ||= File.join(__FILE__, '../../Gemfile')
 
+  # This bundler/gemfile logic ensures that we are loading
+  # gems from the project directory instead of the user's
+  # global system gem directory.
+  ENV['BUNDLE_GEMFILE'] ||= File.join(__FILE__, '../../Gemfile')
   require 'rubygems'
   gem 'bundler', '2.1.4'
   require 'bundler'
-  
   Bundler.setup(:default)
 
   require "deploy/cli"
+  # Once all setup has been done, hand
+  # over to the Deploy::CLI class.
   Deploy::CLI.run!(*ARGV)
 
 rescue Interrupt
+  # If the user interrupts the process in the split second
+  # that the initial setup is going on, give them a clean
+  # warning.
   $stderr.print "\nWARNING: Cancelled by user"
 
   raise SignalException.new(2)

--- a/lib/deploy/cli.rb
+++ b/lib/deploy/cli.rb
@@ -1,22 +1,28 @@
 #!/usr/bin/env ruby
+
+require_relative 'commands'
+
 require 'commander'
 
 module Deploy
   module CLI
-    extend Commander::CLI
+    PROGRAM_NAME = 'deploy'
 
+    # Basic Commander config
+    extend Commander::CLI
     program :application, "Flight Deploy"
-    program :name, "profile"
+    program :name, PROGRAM_NAME
     program :version, "0.0.1"
     program :description, "Manage automatic profiling of cluster nodes"
     program :help_paging, false
     default_command :help
 
-    if [/^xterm/, /rxvt/, /256color/].all? { |regex| ENV['TERM'] !~ regex }
-      Paint.mode = 0
-    end
-
+    # Block to define methods as class methods,
+    # equivalent to defining a method with `def self.method`
     class << self
+      # Method to uniformly define a command's syntax.
+      # Takes the command and the args string as arguments, and 
+      # sets the command's syntax in the same way every time.
       def cli_syntax(command, args_str = nil)
         command.syntax = [
           PROGRAM_NAME,
@@ -26,5 +32,19 @@ module Deploy
       end
     end
 
+    # Commands go here:
+    # command :example do |c|
+    #   cli_syntax(c)
+    #   c.summary = 'Do something useful'
+    #   c.action Commands, :example
+    #   c.description = ""
+    # end
+    # OPTIONAL: alias_command :something_else, :example
+    #
+    # NOTE: We are using a symbol object when specifying the command name
+    # with `c.action`. We do this because it means we can refer to the
+    # commands by name without having to import the class for every single
+    # one in this file. We could also use a string, if we wanted to.
+    # See Deploy::Commands::method_missing for more information.
   end
 end

--- a/lib/deploy/command.rb
+++ b/lib/deploy/command.rb
@@ -1,0 +1,24 @@
+require 'ostruct'
+
+module Deploy
+  class Command
+    attr_accessor :args, :options
+
+    def initialize(args, options, command_name = nil)
+      # Object#freeze prevents an object from being modified.
+      # An error will be raised if modification is attempted.
+      # This cannot be undone.
+      @args = args.freeze
+      @options = OpenStruct.new(options)
+    end
+
+    # This is for future error handling &/ logging
+    def run!
+      run
+    end
+    
+    def run
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/deploy/commands.rb
+++ b/lib/deploy/commands.rb
@@ -1,0 +1,46 @@
+# Here, use `require_relative` to add new commands in the `lib/deploy/commands/`
+# directory to the command line interface. e.g.
+# require_relative 'commands/example'
+
+module Deploy
+  module Commands
+    class << self
+      def method_missing(s, *a, &b)
+        # This overwrites the default Ruby behaviour for when a method is
+        # called that is missing. If a command that the user called is "missing",
+        # do some checks before throwing it away.
+        if clazz = to_class(s)
+          # This block is reached if a command is called with something other
+          # than a class. You will notice that the command definitions in
+          # Deploy::CLI are using symbols.
+          # See if the argument used can be converted to a class,
+          # and if it can, create a new instance and run it.
+          clazz.new(*a).run!
+        else
+          # If the 'command' converted doesn't exist as a class,
+          # then it truly is invalid.
+          raise 'command not defined'
+        end
+      end
+
+      def respond_to_missing?(s)
+        # This is some Ruby magic that, when combined with #method_missing,
+        # lets Ruby treat an "invalid" command as valid, if the #method_missing
+        # check would return it as such.
+        !!to_class(s)
+      end
+
+      private
+
+      def to_class(s)
+        # Interpret the given string and try and convert it to a class.
+        s.to_s.split('-').reduce(self) do |clazz, p|
+          p.gsub!(/_(.)./) { |a| a[1].upcase }
+          clazz.const_get(p[0].upcase + p[1..-1])
+        end
+      rescue NameError
+        nil
+      end
+    end
+  end
+end

--- a/lib/deploy/commands/example.rb
+++ b/lib/deploy/commands/example.rb
@@ -1,0 +1,15 @@
+# Import command class so we can inherit from it later
+require_relative '../command'
+
+# `require_relative` imports a file specifically at the
+# given file path, rather than `require` using the $LOAD_PATH
+
+module Deploy
+  module Commands
+    class Example < Command
+      def run
+        # Here goes what the command actually does when run
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces a baseline `Commander` setup to the application. Based on these additions, new commands can easily be added to the project. Extensive documentation has been added to all of the new additions, explaining what is going on with some of the less self-explanatory logic, and how new commands can be added with the `Commander` syntax.