### PR TITLE
Stop errors overwriting command in setup log file

### DIFF
--- a/lib/deploy/commands/setup.rb
+++ b/lib/deploy/commands/setup.rb
@@ -53,8 +53,7 @@ module Deploy
               "NODE" => node.hostname
             },
             "echo #{cmd}; #{cmd}",
-            out: log_name,
-            err: log_name,
+            [:out, :err] => log_name,
           )
 
           Process.wait(sub_pid)


### PR DESCRIPTION
Tested by editing the path to the ansible file in the login profile yaml file, then running setup on the head node, to get the error:

`ERROR! the playbook: /home/openflight/openflight-ansible-playbook/main.yml1 could not be found`

The error now appears after the command in the log file.

Fixes #14 