### PR TITLE
Dev/clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ spec/examples.txt
 log/*.log
 var/ansible_invs/*.inv
 var/inventory/*.yaml
+openflight-ansible-playbook*
 

--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -52,7 +52,7 @@ EOF
     end
 
     command :apply do |c|
-      cli_syntax(c, ['HOSTNAME[,HOSTNAME...]', 'IDENTITY'])
+      cli_syntax(c, ['NODE[,NODE...]', 'IDENTITY'])
       c.summary = "Apply an identity to one or more nodes"
       c.action Commands, :apply
       c.description = <<EOF
@@ -71,10 +71,20 @@ EOF
     alias_command :ls, :list
 
     command :clean do |c|
-      cli_syntax(c)
-      c.summary = "Remove failed nodes from list output"
+      cli_syntax(c, '[NODE,NODE,...]')
+      c.summary = "Remove data for nodes that failed setup"
       c.action Commands, :clean
-      c.description = "Remove nodes that did not successfully deploy from the output of the list command."
+      c.description = <<EOF
+Remove one or more nodes that failed setup to prevent them from appearing 
+in the output of `profile list`.
+
+Specify a node to remove by passing the node's hostname as an optional 
+parameter. To remove multiple nodes, enter the nodes' hostnames separated 
+by commas. 
+
+If no nodes are specified, data for all nodes that are marked as 'FAILED' 
+will be removed.
+EOF
     end
 
     command :configure do |c|

--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -70,6 +70,13 @@ EOF
     end
     alias_command :ls, :list
 
+    command :clean do |c|
+      cli_syntax(c)
+      c.summary = "Remove failed nodes from list output"
+      c.action Commands, :clean
+      c.description = "Remove nodes that did not successfully deploy from the output of the list command."
+    end
+
     command :configure do |c|
       cli_syntax(c)
       c.summary = "Set the name and IP range of the cluster"

--- a/lib/profile/commands.rb
+++ b/lib/profile/commands.rb
@@ -4,6 +4,7 @@ require_relative 'commands/apply'
 require_relative 'commands/configure'
 require_relative 'commands/view'
 require_relative 'commands/avail'
+require_relative 'commands/clean'
 
 module Profile
   module Commands

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -90,7 +90,7 @@ module Profile
               node.delete if failure.nil? || failure.include?('Waiting for nodes to be reachable')
             end
           end
-          node.update(deployment_pid: pid) unless node.deleted
+          node.update(deployment_pid: pid)
           Process.detach(pid)
         end
       end

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -80,15 +80,7 @@ module Profile
               )
             Process.wait(sub_pid)
             node.update(deployment_pid: nil, exit_status: $?.exitstatus)
-
-            if node.status == 'failed'
-              inventory.remove_node(node, identity.group_name)
-              failure = node.log_file
-                            .readlines
-                            .select { |line| line.start_with?('TASK') }
-                            .last
-              node.delete if failure.nil? || failure.include?('Waiting for nodes to be reachable')
-            end
+            inventory.remove_node(node, profile.group_name) if node.status == 'failed'
           end
           node.update(deployment_pid: pid)
           Process.detach(pid)

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -22,7 +22,7 @@ module Profile
         existing = [].tap do |e|
           hostnames.each do |name|
             node = Node.find(name)
-            e << name if node && node.status != 'failed'
+            e << name if node
           end
         end
 
@@ -80,7 +80,6 @@ module Profile
               )
             Process.wait(sub_pid)
             node.update(deployment_pid: nil, exit_status: $?.exitstatus)
-            inventory.remove_node(node, profile.group_name) if node.status == 'failed'
           end
           node.update(deployment_pid: pid)
           Process.detach(pid)

--- a/lib/profile/commands/clean.rb
+++ b/lib/profile/commands/clean.rb
@@ -1,0 +1,11 @@
+require_relative '../command'
+
+module Profile
+  module Commands
+    class Clean < Command
+      def run
+        puts "Hey"
+      end
+    end
+  end
+end

--- a/lib/profile/commands/clean.rb
+++ b/lib/profile/commands/clean.rb
@@ -4,7 +4,9 @@ module Profile
   module Commands
     class Clean < Command
       def run
-        puts "Hey"
+        Node.all.each do |node|
+          node.delete if node.status == 'failed'
+        end
       end
     end
   end

--- a/lib/profile/commands/clean.rb
+++ b/lib/profile/commands/clean.rb
@@ -1,11 +1,25 @@
 require_relative '../command'
+require_relative '../outputs'
 
 module Profile
   module Commands
     class Clean < Command
+      include Profile::Outputs
       def run
-        Node.all.each do |node|
-          node.delete if node.status == 'failed'
+        hostnames = args[0]
+        if hostnames
+          hostnames.split(',').each do |hostname|
+            node = Node.find(hostname)
+            if node.status == 'failed'
+              node.delete
+            else
+              say_warning "Node '#{hostname}' has not failed setup so will not be removed"
+            end
+          end
+        else
+          Node.all.each do |node|
+            node.delete if node.status == 'failed'
+          end
         end
       end
     end

--- a/lib/profile/commands/view.rb
+++ b/lib/profile/commands/view.rb
@@ -25,7 +25,7 @@ HEREDOC
       end
 
       def node
-        @node ||= Node.find(@hostname) || Node.new(hostname: @hostname)
+        @node ||= Node.find(@hostname)
       end
 
       def display_task_status

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -58,7 +58,6 @@ module Profile
 
     def delete
       File.delete(filepath) if File.exist?(filepath)
-      @deleted = true
     end
 
     # **kwargs grabs all of the KeyWord ARGuments and puts them into a single
@@ -89,14 +88,13 @@ module Profile
       end
     end
 
-    attr_accessor :hostname, :identity, :deployment_pid, :exit_status, :deleted
+    attr_accessor :hostname, :identity, :deployment_pid, :exit_status
 
     def initialize(hostname:, identity: nil, deployment_pid: nil, exit_status: nil)
       @hostname = hostname
       @identity = identity
       @deployment_pid = deployment_pid
       @exit_status = exit_status
-      @deleted = false
     end
   end
 end


### PR DESCRIPTION
`clean` command for removing data for failed nodes, to prevent them from showing up in the `list` output.

Accepts node hostnames in a comma separated list as an optional parameter, to allow specifying the nodes to be removed. If no argument is given, all nodes with a status of 'failed' are removed

Fixes #34