### PR TITLE
Improved type preparation

### DIFF
--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -87,6 +87,19 @@ will be removed.
 EOF
     end
 
+    command :prepare do |c|
+      cli_syntax(c, 'TYPE')
+      c.summary = "Prepare dependencies for cluster type"
+      c.action Commands, :prepare
+      c.description =  <<EOF
+Complete any required dependency steps for a given cluster type.
+
+Specify a cluster type by passing the type's ID as a parameter.
+If a cluster type is not given, the currently configured type
+will be used. A type cannot be used until it has been prepared.
+EOF
+    end
+
     command :configure do |c|
       cli_syntax(c)
       c.summary = "Set the name and IP range of the cluster"

--- a/lib/profile/commands.rb
+++ b/lib/profile/commands.rb
@@ -1,10 +1,11 @@
-require_relative 'commands/list'
-require_relative 'commands/identities'
 require_relative 'commands/apply'
-require_relative 'commands/configure'
-require_relative 'commands/view'
 require_relative 'commands/avail'
 require_relative 'commands/clean'
+require_relative 'commands/configure'
+require_relative 'commands/identities'
+require_relative 'commands/list'
+require_relative 'commands/prepare'
+require_relative 'commands/view'
 
 module Profile
   module Commands

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -46,8 +46,6 @@ module Profile
         raise "No identity exists with given name" if !identity
         cmd = identity.command
 
-        cluster_type.prepare
-
         host_term = hostnames.length > 1 ? 'hosts' : 'host'
         printable_hosts = hostnames.map { |h| "'#{h}'" }
         puts "Applying '#{identity.name}' to #{host_term} #{printable_hosts.join(', ')}"

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -41,6 +41,9 @@ module Profile
         cluster_type.questions.each do |q|
           raise "The #{smart_downcase(q.text.delete(':'))} has not been defined. Please run `profile configure`" unless Config.fetch(q.id)
         end
+        unless cluster_type.prepared?
+          raise "Cluster type has not been prepared yet. Please run `profile prepare #{cluster_type.id}`."
+        end
 
         identity = cluster_type.find_identity(args[1])
         raise "No identity exists with given name" if !identity

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -57,7 +57,7 @@ module Profile
         env = {
           "ANSIBLE_HOST_KEY_CHECKING" => "false",
           "INVFILE" => inv_file,
-          "DEPLOYDIR" => Config.root,
+          "RUN_ENV" => cluster_type.run_env
         }.tap do |e|
           cluster_type.questions.each do |q|
             e[q.env] = Config.fetch(q.id)

--- a/lib/profile/commands/avail.rb
+++ b/lib/profile/commands/avail.rb
@@ -8,9 +8,9 @@ module Profile
         raise "No available cluster types" unless Type.all.any?
 
         t = Table.new
-        t.headers('Name', 'ID', 'Description')
+        t.headers('Name', 'ID', 'Description', 'Prepared')
         Type.all.each do |p|
-          t.row( p.name, p.id, p.description )
+          t.row( p.name, p.id, p.description, p.prepared? )
         end
         t.emit
       end

--- a/lib/profile/commands/clean.rb
+++ b/lib/profile/commands/clean.rb
@@ -19,7 +19,7 @@ module Profile
         else
           Node.all.each do |node|
             if node.status && node.delete
-              puts "Node '#{hostname}' removed from inventory."
+              puts "Node '#{node.hostname}' removed from inventory."
             end
           end
         end

--- a/lib/profile/commands/prepare.rb
+++ b/lib/profile/commands/prepare.rb
@@ -10,9 +10,14 @@ module Profile
         cluster_type = Type.find(args[0]) || Type.find(Config.cluster_type)
         raise "Cluster type not found" unless cluster_type
 
+        raise "Cluster type is already prepared." if cluster_type.prepared?
         puts "Preparing '#{cluster_type.name}' cluster type..."
-        cluster_type.prepare
-        puts "'#{cluster_type.name}' prepared."
+        if cluster_type.prepare
+          puts "'#{cluster_type.name}' prepared."
+          cluster_type.verify
+        else
+          raise "Error occurred while preparing. Please check the log for more details."
+        end
       end
     end
   end

--- a/lib/profile/commands/prepare.rb
+++ b/lib/profile/commands/prepare.rb
@@ -1,0 +1,19 @@
+require_relative '../command'
+
+module Profile
+  module Commands
+    class Prepare < Command
+      def run
+        # ARGS:
+        # [ type_id ]
+
+        cluster_type = Type.find(args[0]) || Type.find(Config.cluster_type)
+        raise "Cluster type not found" unless cluster_type
+
+        puts "Preparing '#{cluster_type.name}' cluster type..."
+        cluster_type.prepare
+        puts "'#{cluster_type.name}' prepared."
+      end
+    end
+  end
+end

--- a/lib/profile/type.rb
+++ b/lib/profile/type.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 require 'shash'
 require 'open3'
 
@@ -52,7 +53,10 @@ module Profile
       raise "No script found for preparing the #{name} cluster type" unless File.exists?(prepare_command)
       log_name = "#{Config.log_dir}/#{id}-#{Time.now.to_i}.log"
 
-      Open3.popen2e({ "DEPLOYDIR" => Config.root }, prepare_command)  do |stdin, stdout_stderr, wait_thr|
+      Open3.popen2e(
+        prepare_command,
+        chdir: run_env
+      )  do |stdin, stdout_stderr, wait_thr|
         Thread.new do
           stdout_stderr.each do |l|
             File.open(log_name, "a+") { |f| f.write l}
@@ -64,6 +68,10 @@ module Profile
 
     def prepare_command
       File.join(base_path, 'prepare.sh')
+    end
+
+    def run_env
+      FileUtils.mkdir_p(File.join(base_path, 'run_env/')).first
     end
 
     attr_reader :id, :name, :description, :base_path

--- a/lib/profile/version.rb
+++ b/lib/profile/version.rb
@@ -1,0 +1,29 @@
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Desktop.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Desktop is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Desktop. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Desktop, please visit:
+# https://github.com/alces-flight/flight-desktop
+# ==============================================================================
+module Profile
+  VERSION = '0.0.3'
+end


### PR DESCRIPTION
- `Type#prepare` separated into its own command (no longer run on `apply`)
- Dependencies found by `prepare` put into isolated `run_env/` directory at type root
- `apply` processes now run in the context of `run_env/`

Resolves #39 when merged