### PR TITLE
Hunter integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
+gem 'flight-subprocess', github: 'openflighthpc/flight-subprocess', tag: '0.1.4'
 gem 'commander-openflighthpc', '~> 2.2.0'
 gem 'tty-table'
 gem 'tty-prompt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,24 @@
+GIT
+  remote: https://github.com/openflighthpc/flight-subprocess.git
+  revision: 28cd69e743e15b13b396de4a34e1c5a097d50108
+  tag: 0.1.4
+  specs:
+    flight-subprocess (0.1.0)
+      bcrypt_pbkdf (~> 1.1.0)
+      ed25519 (~> 1.3.0)
+      net-ssh (~> 6.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
+    bcrypt_pbkdf (1.1.0)
     commander-openflighthpc (2.2.0)
       highline (> 1.7.2)
       paint (~> 2.1.0)
       slop (~> 4.8)
+    ed25519 (1.3.0)
     highline (2.0.3)
+    net-ssh (6.1.0)
     paint (2.1.1)
     pastel (0.8.0)
       tty-color (~> 0.5)
@@ -39,6 +52,7 @@ PLATFORMS
 
 DEPENDENCIES
   commander-openflighthpc (~> 2.2.0)
+  flight-subprocess!
   shash (~> 0.0.7)
   tty-prompt
   tty-table

--- a/etc/config.yml.ex
+++ b/etc/config.yml.ex
@@ -1,5 +1,10 @@
 ---
 # Directories containing cluster type definitions
 #type_paths:
+#  -
+#  -
+# Enable the usage of nodes found by hunter (EXPERIMENTAL)
+# Requires `hunter_command` to be set
+#use_hunter:
 # Path to Flight Hunter executable
 #hunter_command:

--- a/etc/config.yml.ex
+++ b/etc/config.yml.ex
@@ -1,3 +1,5 @@
 ---
 # Directories containing cluster type definitions
 #type_paths:
+# Path to Flight Hunter executable
+#hunter_command:

--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -12,7 +12,7 @@ module Profile
     extend Commander::CLI
     program :application, "Flight Profile"
     program :name, PROGRAM_NAME
-    program :version, "0.0.3"
+    program :version, "0.0.4-rc1"
     program :description, "Manage automatic profiling of cluster nodes"
     program :help_paging, false
     default_command :help

--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -67,7 +67,6 @@ EOF
       c.summary = "Display all node information"
       c.action Commands, :list
       c.description = "Display the configuration identity and status of each node."
-      c.slop.bool "--include-hunter", "Include nodes found by Flight Hunter"
     end
     alias_command :ls, :list
 

--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -67,6 +67,7 @@ EOF
       c.summary = "Display all node information"
       c.action Commands, :list
       c.description = "Display the configuration identity and status of each node."
+      c.slop.bool "--include-hunter", "Include nodes found by Flight Hunter"
     end
     alias_command :ls, :list
 

--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require_relative 'commands'
+require_relative 'version'
 
 require 'commander'
 
@@ -12,7 +13,7 @@ module Profile
     extend Commander::CLI
     program :application, "Flight Profile"
     program :name, PROGRAM_NAME
-    program :version, "0.0.4-rc2"
+    program :version, "v#{Profile::VERSION}"
     program :description, "Manage automatic profiling of cluster nodes"
     program :help_paging, false
     default_command :help

--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -12,7 +12,7 @@ module Profile
     extend Commander::CLI
     program :application, "Flight Profile"
     program :name, PROGRAM_NAME
-    program :version, "0.0.4-rc1"
+    program :version, "0.0.4-rc2"
     program :description, "Manage automatic profiling of cluster nodes"
     program :help_paging, false
     default_command :help

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -22,7 +22,7 @@ module Profile
         existing = [].tap do |e|
           hostnames.each do |name|
             node = Node.find(name, include_hunter: true)
-            e << name if node.identity
+            e << name if node&.identity
           end
         end
 

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -14,50 +14,57 @@ module Profile
       include Profile::Outputs
       def run
         # ARGS:
-        # [ hostname, identity ]
+        # [ names, identity ]
         # OPTS:
         # [ force ]
+        @hunter = Config.use_hunter?
+        
+        names = args[0].split(',')
 
-        hostnames = args[0].split(',')
-        existing = [].tap do |e|
-          hostnames.each do |name|
-            node = Node.find(name, include_hunter: true)
-            e << name if node&.identity
-          end
-        end
+        # If using hunter, check to see if node actually exists
+        check_nodes_exist(names) if @hunter
 
-        unless existing.empty?
-          existing_string = "The following nodes already have an applied identity: \n#{existing.join("\n")}"
-          if @options.force
-            say_warning existing_string + "\nContinuing..."
-          else
-            raise existing_string
-          end
-        end
+        # Don't let the user apply to a node that already has a profile
+        disallow_existing_nodes(names)
 
-        raise "A cluster type has not been chosen. Please run `profile configure`" unless Config.cluster_type
+        # Fetch cluster type
         cluster_type = Type.find(Config.cluster_type)
-        raise "Invalid cluster type. Please rerun `profile configure`" unless cluster_type
-        cluster_type.questions.each do |q|
-          raise "The #{smart_downcase(q.text.delete(':'))} has not been defined. Please run `profile configure`" unless Config.fetch(q.id)
-        end
+        raise "Invalid cluster type. Please run `profile configure`" unless cluster_type
         unless cluster_type.prepared?
           raise "Cluster type has not been prepared yet. Please run `profile prepare #{cluster_type.id}`."
         end
 
+        # Check all questions have been answered
+        missing_questions = cluster_type.questions.select { |q| !Config.fetch(q.id) }
+        if missing_questions.any?
+          q_names = missing_questions.map { |q| smart_downcase(q.text.delete(':')) }
+          out = <<~OUT
+          The following config keys have not been set:
+          #{q_names.join("\n")}
+          Please run `profile configure`
+          OUT
+          raise out
+        end
+        
+        # Fetch identity
         identity = cluster_type.find_identity(args[1])
         raise "No identity exists with given name" if !identity
         cmd = identity.command
 
-        host_term = hostnames.length > 1 ? 'hosts' : 'host'
-        printable_hosts = hostnames.map { |h| "'#{h}'" }
-        puts "Applying '#{identity.name}' to #{host_term} #{printable_hosts.join(', ')}"
+        #
+        # ERROR CHECKING OVER; GOOD TO START APPLYING
+        #
 
-        inventory = Inventory.load(Config.config.cluster_name || 'my-cluster')
+        hosts_term = names.length > 1 ? 'hosts' : 'host'
+        printable_names = names.map { |h| "'#{h}'" }
+        puts "Applying '#{identity.name}' to #{hosts_term} #{printable_names.join(', ')}"
+
+        inventory = Inventory.load(Config.cluster_name || 'my-cluster')
         inventory.groups[identity.group_name] ||= []
         inv_file = inventory.filepath
 
         env = {
+          "ANSIBLE_DISPLAY_SKIPPED_HOSTS" => "false",
           "ANSIBLE_HOST_KEY_CHECKING" => "false",
           "INVFILE" => inv_file,
           "RUN_ENV" => cluster_type.run_env
@@ -67,17 +74,27 @@ module Profile
           end
         end
 
-        hostnames.each do |hostname|
+        names.each do |name|
+          hostname =
+            case @hunter
+            when true
+              Node.find(name, include_hunter: true).hostname
+            when false
+              name
+            end
+
           node = Node.new(
             hostname: hostname,
+            name: name,
             identity: args[1],
-            )
+            hunter_label: 'ff'#Node.find(hostname, include_hunter: true).hunter_label
+          )
 
           inventory.groups[identity.group_name] |= [node.hostname]
           inventory.dump
 
           pid = Process.fork do
-            log_name = "#{Config.log_dir}/#{node.hostname}-#{Time.now.to_i}.log"
+            log_name = "#{Config.log_dir}/#{node.name}-#{Time.now.to_i}.log"
             sub_pid = Process.spawn(
               env.merge( {"NODE" => node.hostname} ),
               "echo #{cmd}; #{cmd}",
@@ -98,6 +115,37 @@ module Profile
         str.split.map do |word|
           /[A-Z]{2,}/.match(word) ? word : word.downcase
         end.join(' ')
+      end
+
+      private
+
+      def disallow_existing_nodes(names=[])
+        existing = [].tap do |e|
+          names.each do |name|
+            node = Node.find(name, include_hunter: @hunter)
+            e << name if node&.identity
+          end
+        end
+
+        unless existing.empty?
+          existing_string = "The following nodes already have an applied identity: \n#{existing.join("\n")}"
+          if @options.force
+            say_warning existing_string + "\nContinuing..."
+          else
+            raise existing_string
+          end
+        end
+      end
+
+      def check_nodes_exist(names=[])
+        not_found = names.select { |n| !Node.find(n, include_hunter: true) }
+        if not_found.any?
+          out = <<~OUT
+          The following nodes were not found in Profile or Hunter:
+          #{not_found.join("\n")}
+          OUT
+          raise out
+        end
       end
     end
   end

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -87,7 +87,7 @@ module Profile
             hostname: hostname,
             name: name,
             identity: args[1],
-            hunter_label: 'ff'#Node.find(hostname, include_hunter: true).hunter_label
+            hunter_label: Node.find(name, include_hunter: true).hunter_label
           )
 
           inventory.groups[identity.group_name] |= [node.hostname]

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -22,7 +22,7 @@ module Profile
         existing = [].tap do |e|
           hostnames.each do |name|
             node = Node.find(name)
-            e << name if node
+            e << name if node.identity
           end
         end
 

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -21,7 +21,7 @@ module Profile
         hostnames = args[0].split(',')
         existing = [].tap do |e|
           hostnames.each do |name|
-            node = Node.find(name)
+            node = Node.find(name, include_hunter: true)
             e << name if node.identity
           end
         end

--- a/lib/profile/commands/list.rb
+++ b/lib/profile/commands/list.rb
@@ -7,7 +7,7 @@ module Profile
     class List < Command
       def run
         hunter = @options.include_hunter
-        raise "No nodes to display" if !Node.all(hunter: hunter).any?
+        raise "No nodes to display" if !Node.all(include_hunter: hunter).any?
 
         t = Table.new
         t.headers('Node', 'Identity', 'Status')

--- a/lib/profile/commands/list.rb
+++ b/lib/profile/commands/list.rb
@@ -6,7 +6,8 @@ module Profile
   module Commands
     class List < Command
       def run
-        raise "No nodes to display" if !Node.all.any?
+        hunter = @options.include_hunter
+        raise "No nodes to display" if !Node.all(hunter: hunter).any?
 
         t = Table.new
         t.headers('Node', 'Identity', 'Status')

--- a/lib/profile/commands/list.rb
+++ b/lib/profile/commands/list.rb
@@ -6,13 +6,13 @@ module Profile
   module Commands
     class List < Command
       def run
-        hunter = @options.include_hunter
+        hunter = Config.use_hunter?
         raise "No nodes to display" if !Node.all(include_hunter: hunter).any?
 
         t = Table.new
         t.headers('Node', 'Identity', 'Status')
         Node.all.each do |node|
-          t.row( node.hostname, node.identity, node.status )
+          t.row( node.name, node.identity, node.status )
         end
         t.emit
       end

--- a/lib/profile/commands/view.rb
+++ b/lib/profile/commands/view.rb
@@ -9,7 +9,7 @@ module Profile
       ALL_STATUSES = SUCCESS_STATUSES + FAIL_STATUSES + SKIP_STATUSES
 
       def run
-        @hostname = args[0]
+        @name = args[0]
         puts <<HEREDOC
 
 Running:
@@ -25,8 +25,8 @@ HEREDOC
       end
 
       def node
-        @node ||= Node.find(@hostname)
-        raise "Node '#{@hostname}' not found" unless @node
+        @node ||= Node.find(@name)
+        raise "Node '#{@name}' not found" unless @node
       end
 
       def display_task_status

--- a/lib/profile/config.rb
+++ b/lib/profile/config.rb
@@ -21,7 +21,9 @@ module Profile
       end
 
       def hunter_command
-        ENV['flight_PROFILE_hunter_command'] || config.hunter_command
+        ENV['flight_PROFILE_hunter_command'] ||
+          config.hunter_command ||
+          File.join(ENV.fetch('flight_ROOT', '/opt/flight/'), 'bin/flight hunter')
       end
 
       def command_path

--- a/lib/profile/config.rb
+++ b/lib/profile/config.rb
@@ -24,6 +24,10 @@ module Profile
         config.hunter_command
       end
 
+      def command_path
+        ENV['PATH']
+      end
+
       def config_hash
         @config_hash ||= File.exists?(config_path) ? (YAML.load_file(config_path) || {}) : {}
       end

--- a/lib/profile/config.rb
+++ b/lib/profile/config.rb
@@ -21,7 +21,7 @@ module Profile
       end
 
       def hunter_command
-        config.hunter_command
+        ENV['flight_PROFILE_hunter_command'] || config.hunter_command
       end
 
       def command_path

--- a/lib/profile/config.rb
+++ b/lib/profile/config.rb
@@ -21,9 +21,11 @@ module Profile
       end
 
       def hunter_command
-        ENV['flight_PROFILE_hunter_command'] ||
-          config.hunter_command ||
-          File.join(ENV.fetch('flight_ROOT', '/opt/flight/'), 'bin/flight hunter')
+        command = 
+          ENV['flight_PROFILE_hunter_command'] ||
+            config.hunter_command ||
+            File.join(ENV.fetch('flight_ROOT', '/opt/flight/'), 'bin/flight hunter')
+        command.split(' ')
       end
 
       def command_path

--- a/lib/profile/config.rb
+++ b/lib/profile/config.rb
@@ -20,6 +20,14 @@ module Profile
         config.cluster_type
       end
 
+      def cluster_name
+        config.cluster_name
+      end
+
+      def use_hunter?
+        config.use_hunter
+      end
+
       def hunter_command
         command = 
           ENV['flight_PROFILE_hunter_command'] ||

--- a/lib/profile/config.rb
+++ b/lib/profile/config.rb
@@ -20,6 +20,10 @@ module Profile
         config.cluster_type
       end
 
+      def hunter_command
+        config.hunter_command
+      end
+
       def config_hash
         @config_hash ||= File.exists?(config_path) ? (YAML.load_file(config_path) || {}) : {}
       end

--- a/lib/profile/hunter_cli.rb
+++ b/lib/profile/hunter_cli.rb
@@ -31,7 +31,7 @@ module Profile
       end
     end
 
-    def initialize(*cmd, user: nil, stdin: nil, timeout: nil, env: {})
+    def initialize(*cmd, user: nil, stdin: nil, timeout: 30, env: {})
       @timeout = timeout
       @cmd = cmd
       @user = user

--- a/lib/profile/hunter_cli.rb
+++ b/lib/profile/hunter_cli.rb
@@ -9,7 +9,8 @@ module Profile
     class << self
       def list_nodes
         args = [
-          "list-parsed"
+          "list",
+          "--plain"
         ]
         cmd = new(*flight_hunter, *args)
         cmd.run.tap do |result|

--- a/lib/profile/hunter_cli.rb
+++ b/lib/profile/hunter_cli.rb
@@ -1,0 +1,70 @@
+require 'open3'
+require 'logger'
+require 'flight/subprocess'
+
+require_relative './config'
+
+module Profile
+  class HunterCLI
+    class << self
+      def list_nodes
+        args = [
+          "list-parsed"
+        ]
+        cmd = new(*flight_hunter, *args)
+        cmd.run.tap do |result|
+          if result.success?
+            return result.stdout
+          else
+            puts "ERROR"
+          end
+        end
+      end
+
+      private
+
+      def flight_hunter
+        Config.hunter_command
+      end
+    end
+
+    def initialize(*cmd, user: nil, stdin: nil, timeout: nil, env: {})
+      @timeout = timeout
+      @cmd = cmd
+      @user = user
+      @stdin = stdin
+      @env = {
+        'PATH' => Config.command_path,
+      }.merge(env)
+    end
+
+    def run(&block)
+      process = Flight::Subprocess::Local.new(
+        env: @env,
+        logger: Logger.new(File.join(Config.log_dir,'hunter')),
+        timeout: @timeout,
+      )
+      result = process.run(@cmd, @stdin, &block)
+      parse_result(result)
+      result
+    end
+
+    private
+
+    def parse_result(result)
+      if result.exitstatus == 0 && expect_json_response?
+        begin
+          unless result.stdout.nil? || result.stdout.strip == ''
+            result.stdout = JSON.parse(result.stdout)
+          end
+        rescue JSON::ParserError
+          result.exitstatus = 128
+        end
+      end
+    end
+
+    def expect_json_response?
+      @cmd.any? { |i| i.strip == '--json' }
+    end
+  end
+end

--- a/lib/profile/hunter_cli.rb
+++ b/lib/profile/hunter_cli.rb
@@ -24,6 +24,9 @@ module Profile
       private
 
       def flight_hunter
+        if !Config.hunter_command
+          raise "Hunter command is not defined"
+        end
         Config.hunter_command
       end
     end

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -17,9 +17,10 @@ module Profile
           )
         end
         if include_hunter
-          hunter_nodes.each do |node|
-            a.concat([node]) unless a.any? { |n| n.hostname == node.hostname }
+          hunter_nodes = list_hunter_nodes.reject do |node|
+            node.hostname.empty? || a.any? { |e| e.hostname == node.hostnme }
           end
+          a.concat(hunter_nodes)
         end
       end.sort_by { |n| n.hostname }
     end
@@ -32,7 +33,7 @@ module Profile
       Node.all.map(&:save)
     end
 
-    def self.hunter_nodes
+    def self.list_hunter_nodes
       result = HunterCLI.list_nodes
       result.split("\n").map do |line|
         parts = line.split("\t").map { |p| p.empty? ? nil : p }

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -5,7 +5,7 @@ require_relative './hunter_cli'
 
 module Profile
   class Node
-    def self.all(hunter: false)
+    def self.all(include_hunter: false)
       @all_nodes ||= [].tap do |a|
         Dir["#{Config.inventory_dir}/*.yaml"].each do |file|
           node = YAML.load_file(file)
@@ -16,7 +16,7 @@ module Profile
             exit_status: node['exit_status']
           )
         end
-        if hunter
+        if include_hunter
           hunter_nodes.each do |node|
             a.concat([node]) unless a.any? { |n| n.hostname == node.hostname }
           end
@@ -24,8 +24,8 @@ module Profile
       end.sort_by { |n| n.hostname }
     end
 
-    def self.find(hostname=nil)
-      all.find { |node| node.hostname == hostname }
+    def self.find(hostname=nil, include_hunter: false)
+      all(include_hunter: include_hunter).find { |node| node.hostname == hostname }
     end
 
     def self.save_all

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -5,7 +5,7 @@ require_relative './hunter_cli'
 
 module Profile
   class Node
-    def self.all
+    def self.all(hunter: false)
       @all_nodes ||= [].tap do |a|
         Dir["#{Config.inventory_dir}/*.yaml"].each do |file|
           node = YAML.load_file(file)
@@ -16,7 +16,7 @@ module Profile
             exit_status: node['exit_status']
           )
         end
-        if Config.hunter_command
+        if hunter
           a.concat(hunter_nodes)
         end
       end.sort_by { |n| n.hostname }
@@ -32,7 +32,7 @@ module Profile
 
     def self.hunter_nodes
       result = HunterCLI.list_nodes
-        result.split("\n").map do |line|
+      result.split("\n").map do |line|
         parts = line.split("\t").map { |p| p.empty? ? nil : p }
         new(
          hostname: parts[1],

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -17,7 +17,9 @@ module Profile
           )
         end
         if hunter
-          a.concat(hunter_nodes)
+          hunter_nodes.each do |node|
+            a.concat([node]) unless a.any? { |n| n.hostname == node.hostname }
+          end
         end
       end.sort_by { |n| n.hostname }
     end

--- a/lib/profile/version.rb
+++ b/lib/profile/version.rb
@@ -25,5 +25,5 @@
 # https://github.com/alces-flight/flight-desktop
 # ==============================================================================
 module Profile
-  VERSION = '0.0.4-rc2'
+  VERSION = '0.0.4-rc3'
 end

--- a/lib/profile/version.rb
+++ b/lib/profile/version.rb
@@ -25,5 +25,5 @@
 # https://github.com/alces-flight/flight-desktop
 # ==============================================================================
 module Profile
-  VERSION = '0.0.3'
+  VERSION = '0.0.4-rc1'
 end

--- a/lib/profile/version.rb
+++ b/lib/profile/version.rb
@@ -25,5 +25,5 @@
 # https://github.com/alces-flight/flight-desktop
 # ==============================================================================
 module Profile
-  VERSION = '0.0.4-rc1'
+  VERSION = '0.0.4-rc2'
 end


### PR DESCRIPTION
This PR adds functionality to interact with Flight Hunter. `avail` can now query Flight Hunter (assuming the path to the Hunter executable has been set) and include nodes from the Hunter parsed list in the output as `Available`.