### PR TITLE
Accommodate multiple commands per identity

### DIFF
--- a/etc/types/openflight-slurm/identities/compute.yaml
+++ b/etc/types/openflight-slurm/identities/compute.yaml
@@ -1,4 +1,5 @@
 name: compute
 description: Set up as a compute node with Flight Runway and job-running tools
 group_name: nodes
-command: "ansible-playbook -i $INVFILE --limit $NODE --extra-vars=\"cluster_name=$CLUSTERNAME compute_ip_range=$IPRANGE\" $RUN_ENV/openflight-ansible-playbook/main.yml"
+commands:
+- main: "ansible-playbook -i $INVFILE --limit $NODE --extra-vars=\"cluster_name=$CLUSTERNAME compute_ip_range=$IPRANGE\" $RUN_ENV/openflight-ansible-playbook/main.yml"

--- a/etc/types/openflight-slurm/identities/login.yaml
+++ b/etc/types/openflight-slurm/identities/login.yaml
@@ -1,4 +1,5 @@
 name: login
 description: Set up as a user-accessible login node with Flight Runway and Flight Web Suite
 group_name: head
-command: "ansible-playbook -i $INVFILE --limit $NODE --extra-vars=\"cluster_name=$CLUSTERNAME compute_ip_range=$IPRANGE\" $RUN_ENV/openflight-ansible-playbook/main.yml"
+commands:
+- main: "ansible-playbook -i $INVFILE --limit $NODE --extra-vars=\"cluster_name=$CLUSTERNAME compute_ip_range=$IPRANGE\" $RUN_ENV/openflight-ansible-playbook/main.yml"

--- a/lib/profile/identity.rb
+++ b/lib/profile/identity.rb
@@ -12,7 +12,7 @@ module Profile
               name: identity['name'],
               description: identity['description'],
               group_name: identity['group_name'],
-              command: identity['command']
+              commands: identity['commands']
             )
           rescue NoMethodError
             puts "Error loading #{file}"
@@ -25,11 +25,15 @@ module Profile
       all(cluster_type).find { |ident| ident.name == name }
     end
 
-    attr_reader :name, :command, :description, :group_name
+    attr_reader :name, :commands, :description, :group_name
 
-    def initialize(name:, command:, description:, group_name:)
+    def initialize(name:, commands:, description:, group_name:)
       @name = name
-      @command = command
+      @commands = [].tap do |l|
+        commands.each do |cmd|
+          l << { name: cmd.keys.first, value: cmd.values.first }
+        end
+      end
       @description = description
       @group_name = group_name
     end

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -72,8 +72,14 @@ module Profile
                                  .last
     end
 
-    def command
-      File.open(log_filepath, &:readline)
+    def commands
+      log = File.read(log_filepath)
+      commands = log.split(/(?=PROFILE_COMMAND)/)
+      commands.map do |cmd|
+        name = cmd.scan(/(?<=PROFILE_COMMAND ).*?(?=:)/)
+        value = cmd.sub /^PROFILE_COMMAND .*: /, ''
+        { name => value }
+      end
     end
 
     def save


### PR DESCRIPTION
This PR adds functionality to list multiple commands per identity in a `profile-type`. Commands are listed in a `key: value` fashion and are executed in the order that they are listed. 