### PR TITLE
Start storing configuration answers in their own files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ spec/examples.txt
 log/*.log
 var/ansible_invs/*.inv
 var/inventory/*.yaml
+var/answers/*.yaml
 openflight-ansible-playbook*
-

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -35,7 +35,7 @@ module Profile
         end
 
         # Check all questions have been answered
-        missing_questions = cluster_type.questions.select { |q| !Config.fetch(q.id) }
+        missing_questions = cluster_type.questions.select { |q| !cluster_type.fetch_answer(q.id) }
         if missing_questions.any?
           q_names = missing_questions.map { |q| smart_downcase(q.text.delete(':')) }
           out = <<~OUT
@@ -70,7 +70,11 @@ module Profile
           "RUN_ENV" => cluster_type.run_env
         }.tap do |e|
           cluster_type.questions.each do |q|
-            e[q.env] = Config.fetch(q.id)
+<<<<<<< Updated upstream
+            e[q.env] = type.fetch_answer(q.id)
+=======
+            e[q.env] = cluster_type.fetch_answer(q.id).to_s
+>>>>>>> Stashed changes
           end
         end
 

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -70,11 +70,7 @@ module Profile
           "RUN_ENV" => cluster_type.run_env
         }.tap do |e|
           cluster_type.questions.each do |q|
-<<<<<<< Updated upstream
-            e[q.env] = type.fetch_answer(q.id)
-=======
             e[q.env] = cluster_type.fetch_answer(q.id).to_s
->>>>>>> Stashed changes
           end
         end
 

--- a/lib/profile/config.rb
+++ b/lib/profile/config.rb
@@ -62,12 +62,16 @@ module Profile
         @root ||= File.expand_path('../..', __dir__)
       end
 
+      def answers_dir
+        dir_constructor(root, 'var', 'answers/')
+      end
+
       def config_path
         File.join(root, "etc/config.yml")
       end
 
       def inventory_dir
-        File.join(root, "var", "inventory")
+        dir_constructor(root, "var", "inventory")
       end
 
       def log_dir
@@ -75,11 +79,18 @@ module Profile
       end
 
       def ansible_inv_dir
-        File.join(root, "var", "ansible_invs")
+        dir_constructor(root, "var", "ansible_invs")
       end
 
       def type_paths
         (config.type_paths || [File.join(root, "etc/types")])
+      end
+
+      private
+
+      def dir_constructor(*a)
+        dir = File.join(*a) 
+        FileUtils.mkdir_p(dir).first
       end
     end
   end

--- a/lib/profile/type.rb
+++ b/lib/profile/type.rb
@@ -2,6 +2,8 @@ require 'fileutils'
 require 'shash'
 require 'open3'
 
+require_relative './config'
+
 module Profile
   class Type
     def self.all
@@ -15,7 +17,6 @@ module Profile
               rescue Errno::ENOENT
                 state = false
               end
-
 
               a << new(
                 id: type['id'],
@@ -42,6 +43,25 @@ module Profile
 
     def self.find(name)
       all.find { |type| type.name == name || type.id == name }
+    end
+
+    def fetch_answer(id)
+      answers[id]
+    end
+
+    def save_answers(answers_hash)
+      new_answers = answers.merge(answers_hash)
+      File.write(answers_file, YAML.dump(new_answers))
+    end
+
+    def answers
+      @answers ||= YAML.load_file(answers_file)
+    rescue Errno::ENOENT
+      {}
+    end
+
+    def answers_file
+      File.join(Config.answers_dir, "#{id}.yaml")
     end
 
     def prepared?


### PR DESCRIPTION
This PR changes Flight Profile to move where the cluster type answers are stored. Previously, they were stored in the application config file at `etc/config.yml`. Storing them there meant that key conflicts would arise if the user wanted to name a cluster type question the same thing as an existing top-level config key. They are now being stored in their own file(s) in the `var/answers/` directory.
Storing the answers here:
- Separates the 'cluster type config' from the 'application config'; they're completely different pieces of data and shouldn't really share a file
- Stops us from having to write to the application config so often (mis-development/configuration could cause problems far too easily)
- Means that if the user switched cluster types their configuration answers would persist if they were to later switch back (they wouldn't have to re-configure every time)