### PR TITLE
Include IPs in Ansible inventory

### DIFF
--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -88,7 +88,7 @@ module Profile
             when true
               Node.find(name, include_hunter: true).ip
             when false
-              name
+              nil
             end
 
           node = Node.new(
@@ -99,8 +99,11 @@ module Profile
             ip: ip
           )
 
-
-          inv_row = "#{node.hostname} ansible_host=#{node.ip}"
+          if @hunter
+            inv_row = "#{node.hostname} ansible_host=#{node.ip}"
+          else
+            inv_row = "#{node.hostname}"
+          end
           inventory.groups[identity.group_name] |= [inv_row]
           inventory.dump
 

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -99,7 +99,9 @@ module Profile
             ip: ip
           )
 
-          inventory.groups[identity.group_name] |= [node.hostname + " ansible_host=" + node.ip]
+
+          inv_row = "#{node.hostname} ansible_host=#{node.ip}"
+          inventory.groups[identity.group_name] |= [inv_row]
           inventory.dump
 
           pid = Process.fork do

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -83,14 +83,23 @@ module Profile
               name
             end
 
+          ip =
+            case @hunter
+            when true
+              Node.find(name, include_hunter: true).ip
+            when false
+              name
+            end
+
           node = Node.new(
             hostname: hostname,
             name: name,
             identity: args[1],
-            hunter_label: Node.find(name, include_hunter: true).hunter_label
+            hunter_label: Node.find(name, include_hunter: true).hunter_label,
+            ip: ip
           )
 
-          inventory.groups[identity.group_name] |= [node.hostname]
+          inventory.groups[identity.group_name] |= [node.hostname + " ansible_host=" + node.ip]
           inventory.dump
 
           pid = Process.fork do

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -95,7 +95,7 @@ module Profile
             hostname: hostname,
             name: name,
             identity: args[1],
-            hunter_label: Node.find(name, include_hunter: true).hunter_label,
+            hunter_label: Node.find(name, include_hunter: true)&.hunter_label,
             ip: ip
           )
 

--- a/lib/profile/inventory.rb
+++ b/lib/profile/inventory.rb
@@ -36,7 +36,7 @@ module Profile
     end
 
     def remove_node(node, group_name)
-      groups[group_name].delete(node.hostname)
+      groups[group_name].delete(node.hostname + " ansible_host=" + node.ip)
       groups.delete(group_name) if groups[group_name].empty?
       dump
     end

--- a/lib/profile/inventory.rb
+++ b/lib/profile/inventory.rb
@@ -36,7 +36,8 @@ module Profile
     end
 
     def remove_node(node, group_name)
-      groups[group_name].delete(node.hostname + " ansible_host=" + node.ip)
+      name = "#{node.hostname} ansible_host=#{node.ip}"
+      groups[group_name].delete(name)
       groups.delete(group_name) if groups[group_name].empty?
       dump
     end

--- a/lib/profile/inventory.rb
+++ b/lib/profile/inventory.rb
@@ -36,7 +36,11 @@ module Profile
     end
 
     def remove_node(node, group_name)
-      name = "#{node.hostname} ansible_host=#{node.ip}"
+      if Config.use_hunter?
+        name = "#{node.hostname} ansible_host=#{node.ip}"
+      else
+        name = node.hostname
+      end
       groups[group_name].delete(name)
       groups.delete(group_name) if groups[group_name].empty?
       dump

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -14,7 +14,8 @@ module Profile
             identity: node['identity'],
             deployment_pid: node['deployment_pid'],
             exit_status: node['exit_status'],
-            name: File.basename(file, '.*')
+            name: File.basename(file, '.*'),
+            ip: node['ip']
           )
         end
         if include_hunter
@@ -43,7 +44,8 @@ module Profile
         parts = line.split("\t").map { |p| p.empty? ? nil : p }
         new(
           hostname: parts[1],
-          hunter_label: parts[4]
+          hunter_label: parts[4],
+          ip: parts[2]
         )
       end
     end
@@ -53,7 +55,8 @@ module Profile
         'hostname' => hostname,
         'identity' => identity,
         'deployment_pid' => deployment_pid,
-        'exit_status' => exit_status
+        'exit_status' => exit_status,
+        'ip' => ip
       }
     end
 
@@ -122,15 +125,16 @@ module Profile
     end
 
     attr_reader :name
-    attr_accessor :hostname, :identity, :deployment_pid, :exit_status, :hunter_label
+    attr_accessor :hostname, :identity, :deployment_pid, :exit_status, :hunter_label, :ip
 
-    def initialize(hostname:, identity: nil, deployment_pid: nil, exit_status: nil, hunter_label: nil, name: nil)
+    def initialize(hostname:, identity: nil, deployment_pid: nil, exit_status: nil, hunter_label: nil, name: nil, ip: "Unknown")
       @hostname = hostname
       @identity = identity
       @deployment_pid = deployment_pid
       @exit_status = exit_status
       @hunter_label = hunter_label
       @name = name || hunter_label || hostname
+      @ip = ip
     end
   end
 end

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -127,7 +127,7 @@ module Profile
     attr_reader :name
     attr_accessor :hostname, :identity, :deployment_pid, :exit_status, :hunter_label, :ip
 
-    def initialize(hostname:, identity: nil, deployment_pid: nil, exit_status: nil, hunter_label: nil, name: nil, ip: "Unknown")
+    def initialize(hostname:, identity: nil, deployment_pid: nil, exit_status: nil, hunter_label: nil, name: nil, ip: nil)
       @hostname = hostname
       @identity = identity
       @deployment_pid = deployment_pid


### PR DESCRIPTION
This PR restructures the Ansible inventory to match the desired format given in #63, such that the IPs stored by Hunter are given alongside hostnames, e.g.
```
[login]
matt-test1.novalocal ansible_host=10.50.0.48

[compute]
matt-test2.novalocal ansible_host=10.50.0.31
```
This format is also now how the nodes are stored in the `groups` hash.