### PR TITLE
Fix clean command

### DIFF
--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -59,7 +59,7 @@ module Profile
         printable_names = names.map { |h| "'#{h}'" }
         puts "Applying '#{identity.name}' to #{hosts_term} #{printable_names.join(', ')}"
 
-        inventory = Inventory.load(Config.cluster_name || 'my-cluster')
+        inventory = Inventory.load(Type.find(Config.cluster_type).fetch_answer("cluster_name"))
         inventory.groups[identity.group_name] ||= []
         inv_file = inventory.filepath
 

--- a/lib/profile/commands/clean.rb
+++ b/lib/profile/commands/clean.rb
@@ -26,7 +26,7 @@ module Profile
           end
         else
           Node.all.each do |node|
-            if node.status && node.delete
+            if node.status == 'failed' && node.delete
               puts "Node '#{node.hostname}' removed from inventory."
             end
           end

--- a/lib/profile/config.rb
+++ b/lib/profile/config.rb
@@ -20,10 +20,6 @@ module Profile
         config.cluster_type
       end
 
-      def cluster_name
-        config.cluster_name
-      end
-
       def use_hunter?
         config.use_hunter
       end

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -91,7 +91,7 @@ module Profile
 
     def delete
       File.delete(filepath) if File.exist?(filepath)
-      inventory = Inventory.load(Config.config.cluster_name)
+      inventory = Inventory.load(Type.find(Config.cluster_type).fetch_answer("cluster_name"))
       inventory.remove_node(self, Identity.find(identity, Config.config.cluster_type).group_name)
     end
 


### PR DESCRIPTION
This PR fixes some issues associated with the `clean` command. The information obtained from `configure` used to be stored in `/etc/config` and some aspects still attempted to read `cluster_name` from there. This caused a couple of issues:

- The `apply` command attempted to read its `cluster_name` from the config file. This in itself didn't throw an error because it was written to instead default to the name `my_cluster` which it would always inevitably do because the cluster name would never correctly be read. The correct cluster name is now used to name the Ansible inventory file.
- The `Node#delete` function also attempted to read its `cluster_name` from the config file. This caused a bad error whenever a node was deleted, although the node's file was deleted before the erroneous line was reached, which is why versions of Profile with this bug would still delete a maximum of one node despite the error.

The `clean` command had another associated issue, being that running it without arguments would clean every possible node. This has also been fixed and it will now correctly only clean nodes identified to have failed setup.