### PR TITLE
Use hunter config option in env merge

### DIFF
--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -112,7 +112,7 @@ module Profile
 
             last_exit = cmds.each do |command|
               sub_pid = Process.spawn(
-                env.merge( { "NODE" => node.hostname} ),
+                env.merge( { "NODE" => node.hostname, "HUNTER_HOSTS" => @hunter.to_s} ),
                 "echo PROFILE_COMMAND #{command[:name]}: #{command[:value]}; #{command[:value]}",
                 [:out, :err] => [log_name, "a+"],
               )

--- a/lib/profile/config.rb
+++ b/lib/profile/config.rb
@@ -25,7 +25,7 @@ module Profile
       end
 
       def use_hunter?
-        config.use_hunter
+        config.use_hunter || false
       end
 
       def hunter_command


### PR DESCRIPTION
This PR addresses #60. The `use_hunter` config option is now used when applying nodes, instead of the answer given in the profile configuration. This change should be combined with changes to `flight-profile-types` to remove the Hunter question from the configuration questions, since its output will be overwritten regardless.