### PR TITLE
Expand square brackets in labels where applicable

### DIFF
--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -27,7 +27,7 @@ module Profile
         end
 
         names.flatten!
-        
+
         # If using hunter, check to see if node actually exists
         check_nodes_exist(names) if @hunter
 
@@ -204,9 +204,9 @@ module Profile
           raise out
         end
       end
-      
+
       def expand_brackets(str)
-        contents = str[/\[.*\]/] 
+        contents = str[/\[.*\]/]
         return [str] if contents.nil?
 
         left = str[/[^\[]*/]

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -20,8 +20,12 @@ module Profile
         # [ force ]
         @hunter = Config.use_hunter?
         
-        names = args[0].split(',')
-
+        strings = args[0].split(',')
+        names = []
+        strings.each do |str|
+          names.append(expand_brackets(str))
+        end
+        
         # If using hunter, check to see if node actually exists
         check_nodes_exist(names) if @hunter
 
@@ -197,6 +201,28 @@ module Profile
           OUT
           raise out
         end
+      end
+      
+      def expand_brackets(str)
+        labels = []
+        contents = str[/\[.*\]/] 
+        if contents.nil?
+          labels = [str]
+        else
+          left = str[/[^\[]*/]
+          right = str[/].*/][1..-1]
+          if contents.match(/^\[[0-9]+-[0-9]+\]$/)
+            nums = contents[1..-2].split("-")
+            (nums.last.to_i - nums.first.to_i + 1).times do |index|
+              cur = (index+nums.first.to_i).to_s
+              label = left + "0" * [(nums.first.length - cur.length), 0].max + cur + right
+              labels.append(label)
+            end
+          else
+            raise "Invalid integer range, ensure any range used is of the form [START-END]"
+          end
+        end
+        labels
       end
     end
   end

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -213,11 +213,10 @@ module Profile
           right = str[/].*/][1..-1]
           if contents.match(/^\[[0-9]+-[0-9]+\]$/)
             nums = contents[1..-2].split("-")
-            (nums.last.to_i - nums.first.to_i + 1).times do |index|
-              cur = (index+nums.first.to_i).to_s
-              label = left + "0" * [(nums.first.length - cur.length), 0].max + cur + right
-              labels.append(label)
             if nums.first.to_i < nums.last.to_i
+              (nums.first..nums.last).each do |index|
+                labels.append(left + index + right)
+              end
             else
               raise "Invalid range, ensure that the end index is greater than the start index"
             end

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -217,6 +217,9 @@ module Profile
               cur = (index+nums.first.to_i).to_s
               label = left + "0" * [(nums.first.length - cur.length), 0].max + cur + right
               labels.append(label)
+            if nums.first.to_i < nums.last.to_i
+            else
+              raise "Invalid range, ensure that the end index is greater than the start index"
             end
           else
             raise "Invalid range, ensure any range used is of the form [START-END]"

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -211,17 +211,19 @@ module Profile
         else
           left = str[/[^\[]*/]
           right = str[/].*/][1..-1]
-          if contents.match(/^\[[0-9]+-[0-9]+\]$/)
-            nums = contents[1..-2].split("-")
-            if nums.first.to_i < nums.last.to_i
-              (nums.first..nums.last).each do |index|
-                labels.append(left + index + right)
-              end
-            else
-              raise "Invalid range, ensure that the end index is greater than the start index"
-            end
-          else
+          
+          unless contents.match(/^\[[0-9]+-[0-9]+\]$/)
             raise "Invalid range, ensure any range used is of the form [START-END]"
+          end
+          
+          nums = contents[1..-2].split("-")
+          
+          unless nums.first.to_i < nums.last.to_i
+            raise "Invalid range, ensure that the end index is greater than the start index"
+          end
+          
+          (nums.first..nums.last).each do |index|
+            labels.append(left + index + right)
           end
         end
         labels

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -23,8 +23,10 @@ module Profile
         strings = args[0].split(',')
         names = []
         strings.each do |str|
-          names.append(expand_brackets(str)).flatten
+          names.append(expand_brackets(str))
         end
+
+        names.flatten!
         
         # If using hunter, check to see if node actually exists
         check_nodes_exist(names) if @hunter

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -23,7 +23,7 @@ module Profile
         strings = args[0].split(',')
         names = []
         strings.each do |str|
-          names.append(expand_brackets(str))
+          names.append(expand_brackets(str)).flatten
         end
         
         # If using hunter, check to see if node actually exists

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -204,29 +204,25 @@ module Profile
       end
       
       def expand_brackets(str)
-        labels = []
         contents = str[/\[.*\]/] 
-        if contents.nil?
-          labels = [str]
-        else
-          left = str[/[^\[]*/]
-          right = str[/].*/][1..-1]
-          
-          unless contents.match(/^\[[0-9]+-[0-9]+\]$/)
-            raise "Invalid range, ensure any range used is of the form [START-END]"
-          end
-          
-          nums = contents[1..-2].split("-")
-          
-          unless nums.first.to_i < nums.last.to_i
-            raise "Invalid range, ensure that the end index is greater than the start index"
-          end
-          
-          (nums.first..nums.last).each do |index|
-            labels.append(left + index + right)
-          end
+        return [str] if contents.nil?
+
+        left = str[/[^\[]*/]
+        right = str[/].*/][1..-1]
+
+        unless contents.match(/^\[[0-9]+-[0-9]+\]$/)
+          raise "Invalid range, ensure any range used is of the form [START-END]"
         end
-        labels
+
+        nums = contents[1..-2].split("-")
+
+        unless nums.first.to_i < nums.last.to_i
+          raise "Invalid range, ensure that the end index is greater than the start index"
+        end
+
+        (nums.first..nums.last).map do |index|
+          left + index + right
+        end
       end
     end
   end

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -219,7 +219,7 @@ module Profile
               labels.append(label)
             end
           else
-            raise "Invalid integer range, ensure any range used is of the form [START-END]"
+            raise "Invalid range, ensure any range used is of the form [START-END]"
           end
         end
         labels

--- a/lib/profile/commands/remove.rb
+++ b/lib/profile/commands/remove.rb
@@ -20,7 +20,13 @@ module Profile
         # [ force ]
         @hunter = Config.use_hunter?
 
-        names = args[0].split(',')
+        strings = args[0].split(',')
+        names = []
+        strings.each do |str|
+          names.append(expand_brackets(str))
+        end
+
+        names.flatten!
 
         # Fetch cluster type
         cluster_type = Type.find(Config.cluster_type)
@@ -134,6 +140,28 @@ module Profile
           else
             raise existing_string
           end
+        end
+      end
+
+      def expand_brackets(str)
+        contents = str[/\[.*\]/]
+        return [str] if contents.nil?
+
+        left = str[/[^\[]*/]
+        right = str[/].*/][1..-1]
+
+        unless contents.match(/^\[[0-9]+-[0-9]+\]$/)
+          raise "Invalid range, ensure any range used is of the form [START-END]"
+        end
+
+        nums = contents[1..-2].split("-")
+
+        unless nums.first.to_i < nums.last.to_i
+          raise "Invalid range, ensure that the end index is greater than the start index"
+        end
+
+        (nums.first..nums.last).map do |index|
+          left + index + right
         end
       end
     end


### PR DESCRIPTION
This PR introduces genders-style range syntax for arguments in `apply`. A user may run `apply node[01-05] compute` to apply the `compute` identity to `node01,node02,node03,node04,node05`. This also has the effect of adding a restriction to what a node name is allowed to be: a node which contains `[` and `]` in the correct order implies that the contents is an attempt to create a range, so a node with a label such as `cluster[login]` would be interpreted as invalid range syntax. It would probably be wise to include some validation of chosen node labels in Hunter to prevent a user being able to create a label which cannot have an identity applied to it.