### PR TITLE
Auto-apply command

### DIFF
--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -53,7 +53,7 @@ EOF
     end
 
     command :apply do |c|
-      cli_syntax(c, ['NODE[,NODE...]', 'IDENTITY'])
+      cli_syntax(c, ['[NODE,NODE...]', '[IDENTITY]'])
       c.summary = "Apply an identity to one or more nodes"
       c.action Commands, :apply
       c.description = <<EOF

--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -61,6 +61,7 @@ Apply an identity to one or more nodes. To set up multiple nodes,
 enter the nodes' hostnames separated by commas.
 EOF
       c.slop.bool "--force", "Overwrite the identity for a node that has already been set up"
+      c.slop.bool "--auto", "Automatically apply an identity to each given node by matching one of its groups to an identity name"
     end
 
     command :list do |c|

--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -53,7 +53,7 @@ EOF
     end
 
     command :apply do |c|
-      cli_syntax(c, ['[NODE,NODE...]', '[IDENTITY]'])
+      cli_syntax(c, ['NODE[,NODE...]', 'IDENTITY'])
       c.summary = "Apply an identity to one or more nodes"
       c.action Commands, :apply
       c.description = <<EOF
@@ -61,7 +61,19 @@ Apply an identity to one or more nodes. To set up multiple nodes,
 enter the nodes' hostnames separated by commas.
 EOF
       c.slop.bool "--force", "Overwrite the identity for a node that has already been set up"
-      c.slop.bool "--auto", "Automatically apply an identity to each given node by matching one of its groups to an identity name"
+    end
+    
+    command "auto-apply" do |c|
+      cli_syntax(c, ['[NODE,NODE...]'])
+      c.summary = "Automatically apply an identity to each given node by matching one of its groups to an identity name"
+      c.action Commands, :autoapply
+      c.description = <<EOF
+Automatically apply an identity to one or more nodes 
+by matching one of its groups to an identity name. 
+A comma-separated list of nodes may be given as an argument, 
+if not given then will autoapply all nodes.
+EOF
+      c.slop.bool "--force", "Overwrite the identity for nodes that have already been set up"
     end
 
     command :list do |c|

--- a/lib/profile/commands.rb
+++ b/lib/profile/commands.rb
@@ -1,4 +1,5 @@
 require_relative 'commands/apply'
+require_relative 'commands/autoapply'
 require_relative 'commands/avail'
 require_relative 'commands/clean'
 require_relative 'commands/configure'

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -59,8 +59,7 @@ module Profile
           else
             node = Node.new(hostname: name)
           end
-          node.identity = args[1]
-          
+
           node.apply_identity(identity, cluster_type)
         end
 

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -18,8 +18,21 @@ module Profile
         # OPTS:
         # [ force, auto ]
         @hunter = Config.use_hunter?
-        
-        names = args[0].split(',')
+
+        if args.to_a.length < 2 && !@options.auto
+          raise "Insufficient arguments for a manual apply"
+        end
+
+        if @options.auto
+          unless @hunter
+            raise "Auto-apply requires use_hunter to be enabled"
+          end
+          if args.empty?
+            names = Node.all(include_hunter: true).map{ |n| n.name }
+          end
+        else
+          names = args[0].split(',')
+        end
 
         # If using hunter, check to see if node actually exists
         check_nodes_exist(names) if @hunter
@@ -79,6 +92,7 @@ module Profile
         names.each do |name|
         
           if @options.auto
+            identity = nil
             Node.find(name, include_hunter: true).groups.each do |group|
               identity = cluster_type.find_identity(group)
               if identity

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -16,7 +16,7 @@ module Profile
         # ARGS:
         # [ names, identity ]
         # OPTS:
-        # [ force ]
+        # [ force, auto ]
         @hunter = Config.use_hunter?
         
         names = args[0].split(',')

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -16,23 +16,10 @@ module Profile
         # ARGS:
         # [ names, identity ]
         # OPTS:
-        # [ force, auto ]
+        # [ force ]
         @hunter = Config.use_hunter?
 
-        if args.to_a.length < 2 && !@options.auto
-          raise "Insufficient arguments for a manual apply"
-        end
-
-        if @options.auto
-          unless @hunter
-            raise "Auto-apply requires use_hunter to be enabled"
-          end
-          if args.empty?
-            names = Node.all(include_hunter: true).map{ |n| n.name }
-          end
-        else
-          names = args[0].split(',')
-        end
+        names = args[0].split(',')
 
         # If using hunter, check to see if node actually exists
         check_nodes_exist(names) if @hunter

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -60,6 +60,7 @@ module Profile
             node = Node.new(hostname: name)
           end
 
+          node.identity_name = identity.name
           node.apply_identity(identity, cluster_type)
         end
 
@@ -79,7 +80,7 @@ module Profile
         existing = [].tap do |e|
           names.each do |name|
             node = Node.find(name, include_hunter: @hunter)
-            e << name if node&.identity
+            e << name if node&.identity_name
           end
         end
 

--- a/lib/profile/commands/autoapply.rb
+++ b/lib/profile/commands/autoapply.rb
@@ -74,16 +74,15 @@ module Profile
               node.identity_name = identity.name
               node.apply_identity(identity, cluster_type)
             end
-            statuses = set.map(&:status)
+            
+            statuses = set.map{ |node| Node.find(node.name).status }
             while !statuses.map{ |status| status == "complete"}.all?
               if statuses.include?("failed")
                 raise "A node has failed to apply, aborting"
               end
-              puts statuses.inspect
-              puts statuses.map{ |status| status == "complete"}.inspect
-              puts statuses.map{ |status| status == "complete"}.all?.inspect
               sleep(5)
-              statuses = set.map(&:status)
+              Node.clear_all
+              statuses = set.map{ |node| Node.find(node.name).status }
             end
           end
         end

--- a/lib/profile/commands/autoapply.rb
+++ b/lib/profile/commands/autoapply.rb
@@ -71,14 +71,19 @@ module Profile
           priority_sets.each do |set|
             set.each do |node|
               identity = node.find_identity(cluster_type)
+              node.identity_name = identity.name
               node.apply_identity(identity, cluster_type)
             end
-            statuses = set.map{ |node| node.status == "complete" }
-            while !statuses.all?
+            statuses = set.map(&:status)
+            while !statuses.map{ |status| status == "complete"}.all?
               if statuses.include?("failed")
                 raise "A node has failed to apply, aborting"
               end
-              statuses = set.map{ |node| node.status == "complete" }
+              puts statuses.inspect
+              puts statuses.map{ |status| status == "complete"}.inspect
+              puts statuses.map{ |status| status == "complete"}.all?.inspect
+              sleep(5)
+              statuses = set.map(&:status)
             end
           end
         end

--- a/lib/profile/commands/autoapply.rb
+++ b/lib/profile/commands/autoapply.rb
@@ -96,7 +96,7 @@ module Profile
         [].tap do |e|
           names.each do |name|
             node = Node.find(name, include_hunter: @hunter)
-            e << name if node&.identity
+            e << name if node&.identity_name
           end
         end
       end

--- a/lib/profile/commands/list.rb
+++ b/lib/profile/commands/list.rb
@@ -12,7 +12,7 @@ module Profile
         t = Table.new
         t.headers('Node', 'Identity', 'Status')
         Node.all.each do |node|
-          t.row( node.name, node.identity, node.status )
+          t.row( node.name, node.identity_name, node.status )
         end
         t.emit
       end

--- a/lib/profile/identity.rb
+++ b/lib/profile/identity.rb
@@ -12,7 +12,8 @@ module Profile
               name: identity['name'],
               description: identity['description'],
               group_name: identity['group_name'],
-              commands: identity['commands']
+              commands: identity['commands'],
+              priority: identity['priority']
             )
           rescue NoMethodError
             puts "Error loading #{file}"
@@ -25,9 +26,9 @@ module Profile
       all(cluster_type).find { |ident| ident.name == name }
     end
 
-    attr_reader :name, :commands, :description, :group_name
+    attr_reader :name, :commands, :description, :group_name, :priority
 
-    def initialize(name:, commands:, description:, group_name:)
+    def initialize(name:, commands:, description:, group_name:, priority:)
       @name = name
       @commands = [].tap do |l|
         commands.each do |cmd|
@@ -36,6 +37,7 @@ module Profile
       end
       @description = description
       @group_name = group_name
+      @priority = priority
     end
   end
 end

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -39,6 +39,10 @@ module Profile
       Node.all.map(&:save)
     end
 
+    def clear_all
+      @all_nodes = nil
+    end
+
     def self.list_hunter_nodes
       result = HunterCLI.list_nodes
       result.split("\n").map do |line|

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -15,7 +15,8 @@ module Profile
             deployment_pid: node['deployment_pid'],
             exit_status: node['exit_status'],
             name: File.basename(file, '.*'),
-            ip: node['ip']
+            ip: node['ip'],
+            groups: node['groups']
           )
         end
         if include_hunter
@@ -44,8 +45,9 @@ module Profile
         parts = line.split("\t").map { |p| p.empty? ? nil : p }
         new(
           hostname: parts[1],
-          hunter_label: parts[4],
-          ip: parts[2]
+          ip: parts[2],
+          groups: parts[3].split("|"),
+          hunter_label: parts[4]
         )
       end
     end
@@ -56,7 +58,8 @@ module Profile
         'identity' => identity,
         'deployment_pid' => deployment_pid,
         'exit_status' => exit_status,
-        'ip' => ip
+        'ip' => ip,
+        'groups' => groups
       }
     end
 
@@ -125,9 +128,9 @@ module Profile
     end
 
     attr_reader :name
-    attr_accessor :hostname, :identity, :deployment_pid, :exit_status, :hunter_label, :ip
+    attr_accessor :hostname, :identity, :deployment_pid, :exit_status, :hunter_label, :ip, :groups
 
-    def initialize(hostname:, identity: nil, deployment_pid: nil, exit_status: nil, hunter_label: nil, name: nil, ip: nil)
+    def initialize(hostname:, identity: nil, deployment_pid: nil, exit_status: nil, hunter_label: nil, name: nil, ip: nil, groups: [])
       @hostname = hostname
       @identity = identity
       @deployment_pid = deployment_pid
@@ -135,6 +138,7 @@ module Profile
       @hunter_label = hunter_label
       @name = name || hunter_label || hostname
       @ip = ip
+      @groups = groups
     end
   end
 end


### PR DESCRIPTION
This PR introduces a new `auto-apply` command which will automatically apply identities to nodes if any of their groups matches the name of an identity for the given cluster type.

- Running `profile auto-apply` will attempt to apply all nodes by default, or a comma separated list of nodes may be given instead.
- The `--force` option is present and works in much the same way as the equivalent option in `apply`
- The groups for each node will be checked in order for group names that match identities. A node with no matching groups will be skipped, and a node with multiple matching identities will have the first valid identity applied to it.
- Each identity for each cluster type now has a `priority` attribute - identities at priority 0 will be applied first, then identities at priority 1, etc. Identities of the same priority will be applied in parallel.

This PR also moves most of the node apply logic out of the `apply` command and into the `Node` class.

In future, it would be good to restructure the `Node` class such that `Node#status` was a variable actually representing the status of any node. This would permit a new "queued" state for nodes which are in the auto-apply process but are still waiting for previous nodes to finish.

This PR should be used in combination with the corresponding change to `flight-profile-types` found here: https://github.com/openflighthpc/flight-profile-types/pull/15