### PR TITLE
Fix error message when type fails to load

### DIFF
--- a/lib/profile/type.rb
+++ b/lib/profile/type.rb
@@ -27,7 +27,7 @@ module Profile
                 base_path: dir
               )
             rescue NoMethodError
-              puts "Error loading #{file}"
+              puts "Error loading #{dir}"
             end
           end
         end


### PR DESCRIPTION
The error handler when loading in a type was calling a variable that didn't exist; this PR changes it to something corporeal and useful.