### PR TITLE
Prevent bad error when removing non-applied nodes

### DIFF
--- a/lib/profile/commands/remove.rb
+++ b/lib/profile/commands/remove.rb
@@ -121,7 +121,7 @@ module Profile
       def check_nodes_not_busy(nodes)
         busy = nodes.select { |node| node.status != 'complete' }
         if busy.any?
-          out = <<~OUT.chomp
+          existing_string = <<~OUT.chomp
           The following nodes are either in a failed process state
           or are currently undergoing a remove/apply process:
           #{busy.map(&:name).join("\n")}


### PR DESCRIPTION
This PR fixes a bug which caused the `remove` command to throw a bad error message when attempting to remove a node which hasn't yet been applied, or doesn't exist.