### PR TITLE
Properly daemonise subprocess

### DIFF
--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -127,8 +127,7 @@ module Profile
             node.update(deployment_pid: nil, exit_status: last_exit)
           end
 
-          node.update(deployment_pid: pid)
-          Process.detach(pid)
+          node.update(deployment_pid: pid.to_i)
         end
 
         puts "The application process has begun. Refer to `flight profile list` "\

--- a/lib/profile/process_spawner.rb
+++ b/lib/profile/process_spawner.rb
@@ -1,9 +1,11 @@
 module Profile
   class ProcessSpawner
     class << self
-
       def run(commands, log_file: nil, env: {})
+        r, w = IO.pipe
         Process.fork do
+          Process.daemon
+          w.puts Process.pid
           with_clean_env do
             last_exit = commands.each_with_index do |command, idx|
               sub_pid = Process.spawn(
@@ -23,6 +25,8 @@ module Profile
             yield last_exit if block_given?
           end
         end
+
+        r.gets.chomp
       end
       
       private


### PR DESCRIPTION
This PR introduces a change to how `ProcessSpawner` launches subprocesses.

Previously, the following would occur:
- `ProcessSpawner` would run `Process.fork`, returning a process ID that would be saved to the node's metadata file under `deployment_pid`.
- The `apply` command logic would run `Process.detach(pid)`, where `pid` is the process ID of the `ProcessSpawner` fork, creating a new thread dedicated to reaping the given process when it exits.
- While the main thread (the one holding IO hostage) ends, and returns control to the user, the other thread (the one watching the subprocess) still exists.
- Because 1 of the 2 threads belonging to the top-level process still exists, the process doesn't end, resulting in `ssh` or Flight Subprocess believing (correctly) that the process is still running.

This PR updates the `ProcessSpawner` fork block to use `Process::daemon` to run the fork as a background process, separate to the top-level Flight Profile process. I'm not going to pretend to understand how it works, because the documentation says "look at the source", which I don't understand. As `Process::daemon` updates the forks process ID, `IO::pipe` is being used to fetch the new PID from inside the fork.