### PR TITLE
Add wait option to apply/remove

### DIFF
--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -55,6 +55,7 @@ EOF
 Apply an identity to one or more nodes. To set up multiple nodes,
 enter the nodes' hostnames separated by commas.
 EOF
+      c.slop.bool '--wait', "Don't daemonise process"
       c.slop.bool "--force", "Overwrite the identity for a node that has already been set up"
     end
 
@@ -63,6 +64,7 @@ EOF
       c.summary = "Remove a node from the cluster"
       c.slop.bool "--remove-hunter-entry", "Delete the node from Flight Hunter (if applicable)"
       c.slop.bool "--force", "Bypass restrictions on removing a node"
+      c.slop.bool '--wait', "Don't daemonise process"
       c.action Commands, :remove
       c.description = <<EOF
 Remove from the cluster a node that has applied to with Profile.

--- a/lib/profile/process_spawner.rb
+++ b/lib/profile/process_spawner.rb
@@ -1,10 +1,10 @@
 module Profile
   class ProcessSpawner
     class << self
-      def run(commands, log_file: nil, env: {})
+      def run(commands, log_file: nil, wait: false, env: {})
         r, w = IO.pipe
         Process.fork do
-          Process.daemon
+          Process.daemon unless wait
           w.puts Process.pid
           with_clean_env do
             last_exit = commands.each_with_index do |command, idx|


### PR DESCRIPTION
# Overview

This PR adds a `--wait` option to the `remove` and `apply` commands. If used, the control process that is spawned to run the identity commands _isn't_ daemonised, resulting in the IO being held until all nodes have finished their process. This is necessary so that the new Flight Profile API (and, therefore, the machine calling the API) has to wait for the process to finish before it can continue with any other steps.

# Future enhancements

The terminal output is very minimal at the moment. The user is given the same information they were before. In the future, (perhaps after we've written in the `watch logs` functionality), it may be useful to output a live update of the logs when the user is `--wait`ing.