### PR TITLE
Smart configure options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ log/*.log
 var/ansible_invs/*.inv
 var/inventory/*.yaml
 var/answers/*.yaml
+var/log/configure
 openflight-ansible-playbook*

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -31,7 +31,7 @@ module Profile
       def ask_questions
         raise "No valid cluster types available" if !Type.all.any?
         type = cluster_type
-        smart_log = Logger.new(File.join(Config.log_dir,'configure'))
+        smart_log = Logger.new(File.join(Config.log_dir,'configure.log'))
         @answers = prompt.collect do
           type.questions.each do |question|
             key(question.id).ask(question.text) do |q|

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -34,11 +34,10 @@ module Profile
         @answers = prompt.collect do
           type.questions.each do |question|
             key(question.id).ask(question.text) do |q|
-              if type.fetch_answer(question.id)
-                q.default type.fetch_answer(question.id)
-              elsif question.default
-                q.default question.default
-              end
+              prefill = type.fetch_answer(question.id) ||
+                        (`#{question.default_smart}`.chomp unless question.default_smart.nil?) ||
+                        question.default
+              q.default prefill
               q.required question.validation.required
               if question.validation.to_h.key?(:format)
                 q.validate Regexp.new(question.validation.format)

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -31,13 +31,31 @@ module Profile
       def ask_questions
         raise "No valid cluster types available" if !Type.all.any?
         type = cluster_type
+        smart_log = Logger.new(File.join(Config.log_dir,'configure'))
         @answers = prompt.collect do
           type.questions.each do |question|
             key(question.id).ask(question.text) do |q|
-              prefill = type.fetch_answer(question.id) ||
-                        (`#{question.default_smart}`.chomp unless question.default_smart.nil?) ||
-                        question.default
+
+              prefill = type.fetch_answer(question.id)
+              if question.default_smart
+                process = Flight::Subprocess::Local.new(
+                  env: {},
+                  logger: smart_log,
+                  timeout: 5,
+                )
+                result = process.run(question.default_smart, nil)
+                output = result.stdout.chomp
+                if !result.success?
+                  smart_log.debug("Command '#{question.default_smart}' failed to run: #{result.stderr}")
+                elsif output.match(Regexp.new(question.validation.format))
+                  prefill ||= output
+                else
+                  smart_log.debug("Command result '#{output}' did not pass validation check for '#{question.text}'")
+                end
+              end
+              prefill ||= question.default
               q.default prefill
+
               q.required question.validation.required
               if question.validation.to_h.key?(:format)
                 q.validate Regexp.new(question.validation.format)

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -37,7 +37,7 @@ module Profile
             key(question.id).ask(question.text) do |q|
 
               prefill = type.fetch_answer(question.id)
-              if question.default_smart
+              if question.default_smart && prefill.nil?
                 process = Flight::Subprocess::Local.new(
                   env: {},
                   logger: smart_log,


### PR DESCRIPTION
This PR enables the use of a new config option in `flight-profile-types` to prefill each configuration question a `default_smart` command, specified in the type's metadata file for each question. Any command placed here will be run, and its output will be given as the prefilled entry if the result is non-empty. For example:

```
  - id: access_host
    env: ACCESS_HOST
    text: 'IP or FQDN for Web Access:'
    default_smart: "curl -s ifconfig.me"
    validation:
      type: string
```
would give the node's public IP as a default value.

The new priority order for these prefilled values is as follows:
* The existing value, if it has already been set previously
* The result of `default_smart`, if it exists and the command produces a result
* The `default` entry string given for that question

If none of the above are given, no prefilled answer is provided.