### PR TITLE
One time configure

### DIFF
--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -119,6 +119,7 @@ Specify a cluster type by passing the type's ID as a parameter.
 If a cluster type is not given, the currently configured type
 will be used. A type cannot be used until it has been prepared.
 EOF
+      c.slop.bool "--reset-type", "Select a different type to that given in config"
     end
 
     command :configure do |c|
@@ -128,6 +129,7 @@ EOF
       c.description = "Set the cluster name and the IP range of your cluster nodes as an IPv4 CIDR block."
       c.slop.bool "--show", "Show the current configuration details."
       c.slop.string "--answers", "Specify answers by JSON string instead of using the prompt."
+      c.slop.bool "--reset-type", "Select a different type to that given in config"
     end
 
     command :view do |c|

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -108,11 +108,19 @@ module Profile
       end
 
       def cluster_type
-        @type ||= Type.find(
-          cli_answers&.delete('cluster_type'), Config.cluster_type
-        ) || Type.find(
-          prompt.select('Cluster type: ', Type.all.map { |t| t.name })
-        )
+        @type ||=
+          if @options.reset_type && !@options.answers
+            Type.find(ask_for_cluster_type)
+          else
+            Type.find(
+              cli_answers&.delete('cluster_type'),
+              Config.cluster_type
+            ) || Type.find(ask_for_cluster_type)
+          end
+      end
+
+      def ask_for_cluster_type
+        prompt.select('Cluster type: ', Type.all.map { |t| t.name })
       end
     end
   end

--- a/lib/profile/commands/prepare.rb
+++ b/lib/profile/commands/prepare.rb
@@ -6,8 +6,14 @@ module Profile
       def run
         # ARGS:
         # [ type_id ]
+        # OPTS:
+        # [ reset_type ]
 
-        cluster_type = Type.find(args[0]) || Type.find(Config.cluster_type)
+        if @options.reset_type
+          cluster_type = Type.find(prompt.select('Cluster type: ', Type.all.map { |t| t.name }))
+        else
+          cluster_type = Type.find(args[0]) || Type.find(Config.cluster_type)
+        end
         raise "Cluster type not found" unless cluster_type
 
         raise "Cluster type is already prepared." if cluster_type.prepared?

--- a/lib/profile/type.rb
+++ b/lib/profile/type.rb
@@ -47,7 +47,7 @@ module Profile
     end
 
     def self.find(*names)
-      self[names.first { |name| self[name] }]
+      self[names.compact.first { |name| self[name] }]
     end
 
     def fetch_answer(id)


### PR DESCRIPTION
This small PR will ensure that `configure` won't ask for the cluster type if it's already been set. A user can also set the cluster type from the config file and avoid using the prompt entirely.