### PR TITLE
Send configure data using JSON

### DIFF
--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -109,7 +109,7 @@ EOF
     end
 
     command :prepare do |c|
-      cli_syntax(c, 'TYPE')
+      cli_syntax(c, '[TYPE]')
       c.summary = "Prepare dependencies for cluster type"
       c.action Commands, :prepare
       c.description =  <<EOF

--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -127,6 +127,7 @@ EOF
       c.action Commands, :configure
       c.description = "Set the cluster name and the IP range of your cluster nodes as an IPv4 CIDR block."
       c.slop.bool "--show", "Show the current configuration details."
+      c.slop.string "--answers", "Specify answers by JSON string instead of using the prompt."
     end
 
     command :view do |c|

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -8,9 +8,7 @@ module Profile
   module Commands
     class Configure < Command
       def run
-        if @options.answers
-          use_cli_options if @options.answers
-        end
+        use_cli_options if @options.answers
 
         if @options.show
           display_details

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -9,7 +9,7 @@ module Profile
     class Configure < Command
       def run
         if @options.answers
-          @answers = JSON.load(@options.answers)
+          use_cli_options if @options.answers
         end
 
         if @options.show
@@ -21,6 +21,15 @@ module Profile
       end
 
       private
+
+      def use_cli_options
+        @answers = JSON.load(@options.answers)
+      rescue JSON::ParserError
+        raise <<~ERROR.chomp
+        Error parsing answers JSON:
+        #{$!.message}
+        ERROR
+      end
 
       def display_details
         raise "Cluster has not yet been configured - please run `configure`" unless Config.cluster_type

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -71,7 +71,7 @@ module Profile
       end
 
       def cluster_type
-        @type ||= Type.find( prompt.select('Cluster type: ', Type.all.map { |t| t.name }) )
+        @type ||= Type.find( Config.cluster_type || prompt.select('Cluster type: ', Type.all.map { |t| t.name }) )
       end
 
       def save_answers

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -96,16 +96,11 @@ module Profile
       end
 
       def cluster_type
-        return @type if @type
-        if @options.answers
-          if @answers.key?("cluster_type")
-            @type ||= Type.find(@answers.delete("cluster_type"))
-          else
-            @type ||= Type.find(Config.cluster_type)
-          end
-        else
-          @type ||= Type.find( Config.cluster_type || prompt.select('Cluster type: ', Type.all.map { |t| t.name }) )
-        end
+        @type ||= if @options.answers
+                    Type.find(@answers.delete("cluster_type") || Config.cluster_type)
+                  else
+                    Type.find( Config.cluster_type || prompt.select('Cluster type: ', Type.all.map { |t| t.name }) )
+                  end
       end
 
       def save_answers

--- a/lib/profile/type.rb
+++ b/lib/profile/type.rb
@@ -42,8 +42,12 @@ module Profile
       end.sort_by { |n| n.name }
     end
 
-    def self.find(name)
+    def self.[](name)
       all.find { |type| type.name == name || type.id == name }
+    end
+
+    def self.find(*names)
+      self[names.first { |name| self[name] }]
     end
 
     def fetch_answer(id)


### PR DESCRIPTION
This PR adds a new option, `--answers`, to `configure`, allowing a user to skip using the interactive prompt and input the answers using JSON instead.

* This PR is based on `enh/one-time-configure` and thus will use the cluster type given in the config if it isn't given in the JSON. If it is given in both JSON and config, the JSON takes priority.
* If the JSON doesn't contain answers to every question for the chosen cluster type, an error is raised listing the missing field(s), and no answers are saved.
* If the JSON contains answers not required by the chosen cluster type, an error is raised listing the unnecessary field(s), and no answers are saved. (In theory this isn't required, but it seems unlikely that a user would intentionally give unnecessary information, it's much more likely to be a typo and/or they set the wrong cluster type)

Example usage:
`./profile configure --answers '{"cluster_type": "openflight-slurm", "cluster_name": "my-cluster", "ip_range": 10.10.0.0/16}'`