### PR TITLE
 Stop detaching from process on remove 

### DIFF
--- a/lib/profile/commands/remove.rb
+++ b/lib/profile/commands/remove.rb
@@ -92,7 +92,6 @@ module Profile
           end
 
           node.update(deployment_pid: pid)
-          Process.detach(pid)
         end
 
         unless @options.wait


### PR DESCRIPTION
This PR stops the `remove` command from trying to detach from the application process. This is something that was already introduced to the `apply` command, and was missed for `remove`.