### PR TITLE
Watch output of view command

### DIFF
--- a/lib/profile/cli.rb
+++ b/lib/profile/cli.rb
@@ -135,6 +135,7 @@ EOF
       c.action Commands, :view
       c.description = "View the setup progress and status of a given node."
       c.slop.bool "--raw", "Show the entire ansible log output."
+      c.slop.bool "--watch", "Constantly refresh and update output."
     end
   end
 end

--- a/lib/profile/commands/view.rb
+++ b/lib/profile/commands/view.rb
@@ -11,9 +11,20 @@ module Profile
       def run
         @name = args[0]
         raise "Node '#{@name}' not found" unless node
-        log = File.read(node.log_file)
-        commands = log.split(/(?=PROFILE_COMMAND)/)
-        commands.each { |cmd| puts command_structure(cmd) }
+
+        if @options.watch
+          begin
+            `tput smcup`
+            loop do
+              display_all
+              sleep(0.5)
+            end
+          rescue Interrupt
+            `tput rmcup`
+          end
+        else
+          display_all
+        end
       end
 
       def command_structure(command)
@@ -33,6 +44,12 @@ Status:
     #{node.status.upcase}
 
 HEREDOC
+      end
+
+      def display_all
+        log = File.read(node.log_file)
+        commands = log.split(/(?=PROFILE_COMMAND)/)
+        commands.each { |cmd| puts command_structure(cmd) }
       end
 
       def node


### PR DESCRIPTION
This PR introduces a new option `--watch` to the `view` command.  It's designed to roughly emulate the output of 
`watch flight profile view <node>`
through the `view` command itself. The user can use Ctrl + C to return to the previous terminal window when desired. The primary upside of using this option instead of the `watch` command is that `--watch` will prioritise printing the end of the log instead of the start, which makes it far more useful to use in combination with `view`.