### PR TITLE
Fix prompt being able to show when using `--answers`

### DIFF
--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -109,13 +109,21 @@ module Profile
 
       def cluster_type
         @type ||=
-          if @options.reset_type && !@options.answers
-            Type.find(ask_for_cluster_type)
+          if @options.answers
+            if @options.reset_type
+              Type.find(cli_answers&.delete('cluster_type'))
+            else
+              Type.find(
+                cli_answers&.delete('cluster_type'),
+                Config.cluster_type
+              )
+            end
           else
-            Type.find(
-              cli_answers&.delete('cluster_type'),
-              Config.cluster_type
-            ) || Type.find(ask_for_cluster_type)
+            if @options.reset_type
+              Type.find(ask_for_cluster_type)
+            else
+              Type.find(Config.cluster_type || ask_for_cluster_type)
+            end
           end
       end
 


### PR DESCRIPTION
Previously, if a cluster type was not given, the prompt would be displayed even when using `--answers`. This PR fixes the behaviour such that the prompt will never be shown when `--answers` is used, and so if a cluster type is not given either in config or in the JSON then an error will be raised.