### PR TITLE
Validate answers before saving them

### DIFF
--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -18,6 +18,7 @@ module Profile
                     when false
                       use_cli_answers
                     end
+          validate_answers(answers)
           save_answers(answers)
         end
       end
@@ -104,6 +105,20 @@ module Profile
         raise <<~ERROR.chomp
         Error parsing answers JSON:
         #{$!.message}
+        ERROR
+      end
+
+      def validate_answers(answers)
+        bad_answers = []
+        cluster_type.questions.each do |q|
+          next unless q.validation.has_key?(:format)
+          criterion = Regexp.new(q.validation.format)
+          bad_answers << q.id unless answers[q.id].match(criterion)
+        end
+        return unless bad_answers.any?
+
+        raise <<~ERROR.chomp
+        The following answers did not pass validation: #{bad_answers.join(', ')}
         ERROR
       end
 


### PR DESCRIPTION
This PR adds an extra step to the `configure` step to ensure that we are validating answers against their questions' format validation.

The call to validate the answers occurs whether the answers were given at CLI or via the interactive prompt. If the user has entered their answers via the interactive prompt, they will already have been validated, but I don't see any harm in validating them again before saving.