### PR TITLE
Add a way to reload node files

### DIFF
--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -171,7 +171,7 @@ module Profile
 
         unless existing.empty?
           existing_string = <<~OUT.chomp
-          "The following nodes already have an applied identity:
+          The following nodes already have an applied identity:
           #{existing.map(&:name).join("\n")}
           OUT
 

--- a/lib/profile/commands/view.rb
+++ b/lib/profile/commands/view.rb
@@ -64,7 +64,7 @@ HEREDOC
       end
 
       def node
-        @node ||= Node.find(@name)
+        Node.find(@name, reload: true)
       end
 
       def display_task_status(command)


### PR DESCRIPTION
This PR adds an option to the `Node::all` function to optionally reload all node files. The `view --watch` command had a bug where it wasn't fetching the node's updated exit status, because it was using the node object stored in memory instead of reloading the file.