### PR TITLE
Truncate log lines when watching raw output

### DIFF
--- a/lib/profile/commands/view.rb
+++ b/lib/profile/commands/view.rb
@@ -18,12 +18,21 @@ module Profile
           in_clean_window do
             loop do
               height = `tput lines`.chomp.to_i
+              width = `tput cols`.chomp.to_i
 
               Curses.noecho
               Curses.curs_set(0)
               Curses.setpos(0, 0)
 
-              Curses.addstr(output.lines.pop(height).join)
+              truncated = output.lines.map do |line|
+                [].tap do |out|
+                  (line.length.to_f / width).ceil.times do |i|
+                    out << line[0+(width*i)..width*(i+1)]
+                  end
+                end
+              end.flatten
+
+              Curses.addstr(truncated.last(height).join)
               Curses.refresh
               sleep 2
             end


### PR DESCRIPTION
When `watch`ing a log output, we print as many lines from the end of the log as there are rows in the current terminal size. If one of these lines has more characters than the terminal width supports, the line would wrap, shifting the entire output downwards. The end of the log would be offset, and the last `n` lines (where `n` is the number of wrapped lines) would be out of view.

This PR further splits lines that are too long into smaller lines, before fetching the last `n` lines of the log (where `n` is the terminal height).

**Before:**
![Screenshot_2023-06-15_15-57-38](https://github.com/openflighthpc/flight-profile/assets/12374447/5b675a73-a13e-4a19-83af-320ba08bcc46)

**After:**

![Screenshot_2023-06-15_15-57-22](https://github.com/openflighthpc/flight-profile/assets/12374447/376ee4fa-228a-4823-abac-1d7667869482)

