### PR TITLE
Use exclusive range index when splitting log lines

### DIFF
--- a/lib/profile/commands/view.rb
+++ b/lib/profile/commands/view.rb
@@ -27,7 +27,7 @@ module Profile
               truncated = output.lines.map do |line|
                 [].tap do |out|
                   (line.length.to_f / width).ceil.times do |i|
-                    out << line[0+(width*i)..width*(i+1)]
+                    out << line[0+(width*i)...width*(i+1)]
                   end
                 end
               end.flatten


### PR DESCRIPTION
As title; the final character was getting duplicated when wrapping lines, due to an inclusive range call.