### PR TITLE
Run smart-default commands concurrently

### DIFF
--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -49,11 +49,14 @@ module Profile
 
         prefills = {}
         type.questions.each do |question|
-          prefills[question.id] = generate_prefill(question)
+          Process.fork do
+            prefills[question.id] = generate_prefill(question)
+          end
         end
         prompt.collect do
           type.questions.each do |question|
             key(question.id).ask(question.text) do |q|
+              sleep(0.25) until prefills[question.id]
               q.default prefills[question.id]
               q.required question.validation.required
               if question.validation.to_h.key?(:format)

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -56,7 +56,7 @@ module Profile
         prompt.collect do
           type.questions.each do |question|
             key(question.id).ask(question.text) do |q|
-              sleep(0.25) until prefills[question.id]
+              sleep(0.25) while !prefills[question.id]
               q.default prefills[question.id]
               q.required question.validation.required
               if question.validation.to_h.key?(:format)

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -49,7 +49,7 @@ module Profile
 
         prefills = {}
         type.questions.each do |question|
-          Process.fork do
+          Thread.fork do
             prefills[question.id] = generate_prefill(question)
           end
         end

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -88,7 +88,7 @@ module Profile
             smart_log.debug("Command result '#{output}' did not pass validation check for '#{question.text}'")
           end
         end
-        prefill ||= question.default
+        prefill = question.default || ""
       end
 
       def display_details

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -88,7 +88,7 @@ module Profile
             smart_log.debug("Command result '#{output}' did not pass validation check for '#{question.text}'")
           end
         end
-        prefill = question.default || ""
+        prefill ||= question.default || ""
       end
 
       def display_details

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -78,7 +78,7 @@ module Profile
           result = process.run(question.default_smart, nil)
           output = result.stdout.chomp
           if !result.success?
-            smart_log.debug("Command '#{question.default_smart}' failed to run: #{result.stderr}")
+            smart_log.debug("Command '#{question.default_smart}' failed to run: #{result.stderr.dump}")
           elsif (!question.validation.has_key?(:format) || output.match(Regexp.new(question.validation.format)))
             prefill ||= output
           else


### PR DESCRIPTION
Previously, all smart-default commands were run sequentially after type selection. This caused significant slowdown if multiple commands ran slowly. This PR causes all smart-default commands to be run concurrently after the type is selected. The rest of the questions will be asked right away, assuming their prefill data is ready. If the prefill is not yet ready, Profile will wait to ask the question until it is. There's still potential for some slowdown for any long commands that are early in the question list, but the command is far more responsive now and it's more clear what you're waiting for.