### PR TITLE
Submit Ansible jobs with more than one node at once

### DIFF
--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -74,6 +74,8 @@ module Profile
         inv_file = inventory.filepath
 
         env = {
+          "ANSIBLE_LOG_FOLDER" => Config.log_dir,
+          "ANSIBLE_STDOUT_CALLBACK" => "log_plays",
           "ANSIBLE_DISPLAY_SKIPPED_HOSTS" => "false",
           "ANSIBLE_HOST_KEY_CHECKING" => "false",
           "INVFILE" => inv_file,
@@ -119,10 +121,13 @@ module Profile
           inventory.dump
 
           log_file = "#{Config.log_dir}/#{node.name}-apply-#{Time.now.to_i}.log"
+          File.symlink(
+            File.join(Config.log_dir, node.hostname),
+            log_file
+          )
 
           pid = ProcessSpawner.run(
             cmds["apply"],
-            log_file: log_file,
             wait: @options.wait,
             env: env.merge({ "NODE" => node.hostname })
           ) do |last_exit|

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -109,6 +109,14 @@ module Profile
 
           inventory.groups[identity.group_name] |= [inv_row]
 
+          node = Node.new(
+            hostname: hostname,
+            name: name,
+            identity: args[1],
+            hunter_label: Node.find(name, include_hunter: true)&.hunter_label,
+            ip: ip
+          )
+
           node.clear_logs
           log_symlink = "#{Config.log_dir}/#{name}-apply-#{Time.now.to_i}.log"
 
@@ -125,13 +133,7 @@ module Profile
             log_symlink
           )
 
-          Node.new(
-            hostname: hostname,
-            name: name,
-            identity: args[1],
-            hunter_label: Node.find(name, include_hunter: true)&.hunter_label,
-            ip: ip
-          )
+          node
         end
 
         inventory.dump

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -109,6 +109,7 @@ module Profile
 
           inventory.groups[identity.group_name] |= [inv_row]
 
+          node.clear_logs
           log_symlink = "#{Config.log_dir}/#{name}-apply-#{Time.now.to_i}.log"
 
           ansible_log_path = File.join(

--- a/lib/profile/commands/remove.rb
+++ b/lib/profile/commands/remove.rb
@@ -114,9 +114,7 @@ module Profile
 
             node_objects.destroy_all if last_exit == 0
             if last_exit == 0 && @hunter && @options.remove_hunter_entry
-              # TODO: update Hunter to allow multiple
-              # node removals in one command call
-              nodes.each { |n| HunterCLI.remove_node(node.name) }
+              HunterCLI.remove_node(nodes.map(&:hunter_label).join(','))
             end
           end
 

--- a/lib/profile/commands/remove.rb
+++ b/lib/profile/commands/remove.rb
@@ -113,7 +113,7 @@ module Profile
           ) do |last_exit|
             node_objs.update_all(deployment_pid: nil, exit_status: last_exit)
 
-            node_objects.destroy_all if last_exit == 0
+            node_objs.destroy_all if last_exit == 0
             if last_exit == 0 && @hunter && @options.remove_hunter_entry
               HunterCLI.remove_node(nodes.map(&:hunter_label).join(','))
             end
@@ -140,6 +140,10 @@ module Profile
       Nodes = Struct.new(:nodes) do
         def update_all(**kwargs)
           nodes.map { |node| node.update(**kwargs) }
+        end
+
+        def destroy_all
+          nodes.each { |node| node.delete }
         end
       end
 

--- a/lib/profile/commands/remove.rb
+++ b/lib/profile/commands/remove.rb
@@ -83,6 +83,7 @@ module Profile
             node.hostname
           )
 
+          node.clear_logs
           log_symlink = "#{Config.log_dir}/#{node.name}-remove-#{Time.now.to_i}.log"
 
           FileUtils.mkdir_p(ansible_log_dir)

--- a/lib/profile/commands/remove.rb
+++ b/lib/profile/commands/remove.rb
@@ -115,7 +115,7 @@ module Profile
 
             node_objs.destroy_all if last_exit == 0
             if last_exit == 0 && @hunter && @options.remove_hunter_entry
-              HunterCLI.remove_node(nodes.map(&:hunter_label).join(','))
+              HunterCLI.remove_node(nodes.map(&:name).join(','))
             end
           end
 

--- a/lib/profile/commands/view.rb
+++ b/lib/profile/commands/view.rb
@@ -46,7 +46,10 @@ module Profile
         log = File.read(node.log_file)
         commands = log.split(/(?=PROFILE_COMMAND)/)
         "".tap do |output|
-          commands.each { |cmd| output << command_structure(cmd) + "\n" }
+          commands.each do|cmd|
+            status = cmd == commands.last ? nil : 'COMPLETE'
+            output << command_structure(cmd, status: status) + "\n"
+          end
         end
       end
 
@@ -59,7 +62,7 @@ module Profile
         end
       end
 
-      def command_structure(command)
+      def command_structure(command, status: nil)
         header = command.split("\n").first.sub /^PROFILE_COMMAND .*: /, ''
         cmd_name = command[/(?<=PROFILE_COMMAND ).*?(?=:)/]
         <<HEREDOC
@@ -73,7 +76,7 @@ Progress:
 #{display_task_status(command).chomp}
 
 Status:
-    #{node.status.upcase}
+    #{status || node.status.upcase}
 
 HEREDOC
       end

--- a/lib/profile/commands/view.rb
+++ b/lib/profile/commands/view.rb
@@ -98,7 +98,7 @@ HEREDOC
 
       def display_task_status(command)
         new_role = nil
-        roles = []
+        roles = Hash.new(0)
         str = ""
         command.split("\n").each_with_index do |line, idx|
           line << "\n"
@@ -113,9 +113,9 @@ HEREDOC
             next if parts['task_role'] == 'None'
 
             role = parts['task_role']
-            new_role = !roles.include?(role)
-            roles << role if new_role
-            str += "#{role}\n" if new_role
+            new_role = !roles.key?(role)
+            roles[role] += 1 unless parts['category'] == 'SKIPPED'
+            str += "#{role}\n" if new_role && roles[role] > 0
 
             if SUCCESS_STATUSES.include?(parts['category']&.downcase)
               str += "   \u2705 #{parts['task_name']}\n"

--- a/lib/profile/commands/view.rb
+++ b/lib/profile/commands/view.rb
@@ -97,7 +97,7 @@ HEREDOC
       def node
         # attempt to find without hunter integration first to save time
         attempts = [
-          lambda { Node.find(@name, reload: true) }
+          lambda { Node.find(@name, reload: true) },
           lambda { Node.find(@name, reload: true, include_hunter: use_hunter?) }
         ]
 

--- a/lib/profile/config.rb
+++ b/lib/profile/config.rb
@@ -74,6 +74,10 @@ module Profile
         @root ||= File.expand_path(File.join(__dir__, '..', '..'))
       end
 
+      def ansible_callback_dir
+        File.join(Config.root, 'opt', 'ansible_callbacks')
+      end
+
       private
 
       def dir_constructor(*a)

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -61,6 +61,12 @@ module Profile
                                  .last
     end
 
+    def clear_logs
+      Dir.glob("#{Config.log_dir}/#{name}-*.log").each do |file|
+        File.delete(file) if File.symlink?(file)
+      end
+    end
+
     def commands
       log = File.read(log_filepath)
       commands = log.split(/(?=PROFILE_COMMAND)/)

--- a/lib/profile/process_spawner.rb
+++ b/lib/profile/process_spawner.rb
@@ -9,16 +9,17 @@ module Profile
           File.delete(log_file) if File.file?(log_file)
 
           with_clean_env do
-            last_exit = commands.each_with_index do |command, idx|
+            ast_exit = commands.each_with_index do |command, idx|
               File.write(
                 log_file,
-                "PROFILE_COMMAND #{command['name']}: #{command['command']}\n",
+                "PROFILE_COMMAND #{command["name"]}: #{command["command"]}\n",
                 mode: 'a'
               )
 
               sub_pid = Process.spawn(
                 env,
-                command['command']
+                command['command'],
+                [:out, :err] => ['/root/flight-profile/test_log', "a+"]
               )
 
               Process.wait(sub_pid)

--- a/lib/profile/process_spawner.rb
+++ b/lib/profile/process_spawner.rb
@@ -6,12 +6,19 @@ module Profile
         Process.fork do
           Process.daemon unless wait
           w.puts Process.pid
+          File.delete(log_file) if File.file?(log_file)
+
           with_clean_env do
             last_exit = commands.each_with_index do |command, idx|
+              File.write(
+                log_file,
+                "PROFILE_COMMAND #{command['name']}: #{command['command']}\n",
+                mode: 'a'
+              )
+
               sub_pid = Process.spawn(
                 env,
-                "echo PROFILE_COMMAND #{command["name"]}: #{command["command"]}; #{command["command"]}",
-                [:out, :err] => [log_file, "a+"]
+                command['command']
               )
 
               Process.wait(sub_pid)

--- a/lib/profile/process_spawner.rb
+++ b/lib/profile/process_spawner.rb
@@ -7,12 +7,17 @@ module Profile
           Process.daemon unless wait
           w.puts Process.pid
 
+          # Ansible appends to logfiles, so we delete the old ones.
+          # We may want to change this to an archival/log rotation process
+          # in the future, but for now I don't think it really matters.
           log_files.each do |file|
             File.delete(File.readlink(file)) if File.file?(file)
           end
 
           with_clean_env do
             last_exit = commands.each_with_index do |command, idx|
+              # We need to initialize the logfiles before Ansible does, so that
+              # we can put our DSL lines in.
               log_files.each do |file|
                 File.write(
                   file,
@@ -23,8 +28,7 @@ module Profile
 
               sub_pid = Process.spawn(
                 env,
-                command['command'],
-                [:out, :err] => ['/root/flight-profile/test_log', "a+"]
+                command['command']
               )
 
               Process.wait(sub_pid)

--- a/opt/ansible_callbacks/log_plays_v2.py
+++ b/opt/ansible_callbacks/log_plays_v2.py
@@ -3,6 +3,10 @@
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is a copy of https://github.com/ansible-collections/community.general/blob/c4a2801f990f6b9486878bc6f789969107cd5fca/plugins/callback/log_plays.py
+#
+# Any modifications from the original source are indicated
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -56,6 +60,9 @@ class CallbackModule(CallbackBase):
     CALLBACK_NEEDS_WHITELIST = True
 
     TIME_FORMAT = "%b %d %Y %H:%M:%S"
+    # OLD
+    #MSG_FORMAT = "%(now)s - %(playbook)s - %(task_name)s - %(task_action)s - %(category)s - %(data)s\n\n"
+    # NEW
     MSG_FORMAT = "%(now)s - %(playbook)s - %(task_role)s - %(task_name)s - %(task_action)s - %(category)s - %(data)s\n\n"
 
     def __init__(self):
@@ -91,7 +98,9 @@ class CallbackModule(CallbackBase):
             % dict(
                 now=now,
                 playbook=self.playbook,
+                # ADDITION START
                 task_role=result._task._role,
+                # ADDITION END
                 task_name=result._task.name,
                 task_action=result._task.action,
                 category=category,

--- a/opt/ansible_callbacks/log_plays_v2.py
+++ b/opt/ansible_callbacks/log_plays_v2.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2012, Michael DeHaan, <michael.dehaan@gmail.com>
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    author: Unknown (!UNKNOWN)
+    name: log_plays
+    type: notification
+    short_description: write playbook output to log file
+    description:
+      - This callback writes playbook output to a file per host in the C(/var/log/ansible/hosts) directory.
+    requirements:
+     - Whitelist in configuration
+     - A writeable C(/var/log/ansible/hosts) directory by the user executing Ansible on the controller
+    options:
+      log_folder:
+        default: /var/log/ansible/hosts
+        description: The folder where log files will be created.
+        env:
+          - name: ANSIBLE_LOG_FOLDER
+        ini:
+          - section: callback_log_plays
+            key: log_folder
+'''
+
+import os
+import time
+import json
+
+from ansible.utils.path import makedirs_safe
+from ansible.module_utils.common.text.converters import to_bytes
+from ansible.module_utils.common._collections_compat import MutableMapping
+from ansible.parsing.ajson import AnsibleJSONEncoder
+from ansible.plugins.callback import CallbackBase
+
+
+# NOTE: in Ansible 1.2 or later general logging is available without
+# this plugin, just set ANSIBLE_LOG_PATH as an environment variable
+# or log_path in the DEFAULTS section of your ansible configuration
+# file.  This callback is an example of per hosts logging for those
+# that want it.
+
+
+class CallbackModule(CallbackBase):
+    """
+    logs playbook results, per host, in /var/log/ansible/hosts
+    """
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'notification'
+    CALLBACK_NAME = 'community.general.log_plays'
+    CALLBACK_NEEDS_WHITELIST = True
+
+    TIME_FORMAT = "%b %d %Y %H:%M:%S"
+    MSG_FORMAT = "%(now)s - %(playbook)s - %(task_role)s - %(task_name)s - %(task_action)s - %(category)s - %(data)s\n\n"
+
+    def __init__(self):
+
+        super(CallbackModule, self).__init__()
+
+    def set_options(self, task_keys=None, var_options=None, direct=None):
+        super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
+
+        self.log_folder = self.get_option("log_folder")
+
+        if not os.path.exists(self.log_folder):
+            makedirs_safe(self.log_folder)
+
+    def log(self, result, category):
+        data = result._result
+        if isinstance(data, MutableMapping):
+            if '_ansible_verbose_override' in data:
+                # avoid logging extraneous data
+                data = 'omitted'
+            else:
+                data = data.copy()
+                invocation = data.pop('invocation', None)
+                data = json.dumps(data, cls=AnsibleJSONEncoder)
+                if invocation is not None:
+                    data = json.dumps(invocation) + " => %s " % data
+
+        path = os.path.join(self.log_folder, result._host.get_name())
+        now = time.strftime(self.TIME_FORMAT, time.localtime())
+
+        msg = to_bytes(
+            self.MSG_FORMAT
+            % dict(
+                now=now,
+                playbook=self.playbook,
+                task_role=result._task._role,
+                task_name=result._task.name,
+                task_action=result._task.action,
+                category=category,
+                data=data,
+            )
+        )
+        with open(path, "ab") as fd:
+            fd.write(msg)
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+        self.log(result, 'FAILED')
+
+    def v2_runner_on_ok(self, result):
+        self.log(result, 'OK')
+
+    def v2_runner_on_skipped(self, result):
+        self.log(result, 'SKIPPED')
+
+    def v2_runner_on_unreachable(self, result):
+        self.log(result, 'UNREACHABLE')
+
+    def v2_runner_on_async_failed(self, result):
+        self.log(result, 'ASYNC_FAILED')
+
+    def v2_playbook_on_start(self, playbook):
+        self.playbook = playbook._file_name
+
+    def v2_playbook_on_import_for_host(self, result, imported_file):
+        self.log(result, 'IMPORTED', imported_file)
+
+    def v2_playbook_on_not_import_for_host(self, result, missing_file):
+        self.log(result, 'NOTIMPORTED', missing_file)


### PR DESCRIPTION
# Overview

This PR introduces some integral changes to the way that we submit Ansible jobs. Previously, when starting an `apply`/`remove` process for multiple nodes, a new Ansible process was started for each node. Now, a single Ansible process is started to handle all of the nodes given at the CLI.

# Important changes

## Splitting logs by host

The default Ansible `stdout` is formatted in a user-friendly way, to show all tasks for all nodes, _grouped by task_. This makes interpreting the log on a per-node basis rather difficult when there is more than one. It also breaks the convention that we use for tracking a node's log, as the task status for multiple nodes would be written to a single file (we store them in one file per node as `var/log/<name>-<action>-<timestamp>.log`). 

Initially, this was solved by using the `log_plays` Ansible stdout callback. The callback writes the playbook output to a file, but more importantly writes it to _one file per host_. The playbook output changes dramatically when using this callback, so the log interpreter in `view` was rewritten.

The `log_plays` callback writes to `<hostname>.log` in the given log directory, again breaking our naming convention. To circumvent this, we tell Ansible to write its logfiles to `var/log/<action>/<hostname>`, and create symlinks with the name we expect pointing to the real logfiles.

Finally, the `log_plays` stdout callback removes some of the output that we rely on when reading logs (namely, the task role). This one is quite difficult to get around cleanly, so the solution was to create our own Ansible callback plugin (based off of `log_plays`) and modify it to give the output we want. This plugin will ship with Flight Profile, and requires no changes to Flight Profile Types (see: `ANSIBLE_CALLBACK_PLUGINS` and `ANSIBLE_STDOUT_CALLBACK` in our action `env` hashes).

## Submitting one Ansible process

The action files have been updated to move most of the Ansible specific logic out of the iterative loop on `nodes`. There is still a loop on `nodes`, but it only contains node-specific logic required to set up logfiles. We are also using a `Struct` wrapper around an array of nodes to update the deployment PID and exit status of all the contained nodes at once.

In the `remove` action, we aren't submitting a single Ansible process, but one process _per identity_. Different identities (potentially) have different `remove` commands, so we group the nodes into one process per identity.

# Limitations

As of now, if one submits an action on a group of nodes, it's impossible to halt an action on just one of them without also halting the actions on the rest of the nodes in that group. A user cannot halt an action on a node without using the `--force` argument, so I don't think I have a problem with the destructive behaviour, as it is covered by the expected (possible) destructiveness of the `--force` argument.