### PR TITLE
Add Access Permissions to the Profile Configuration File

### DIFF
--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -99,9 +99,11 @@ module Profile
         end
       end
 
+      # TODO
       def save_answers(answers)
         Config.data.set(:cluster_type, value: cluster_type.id)
         Config.save_data
+        Config.set_permission
         cluster_type.save_answers(answers)
       end
 

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -99,7 +99,6 @@ module Profile
         end
       end
 
-      # TODO
       def save_answers(answers)
         Config.data.set(:cluster_type, value: cluster_type.id)
         Config.save_data

--- a/lib/profile/config.rb
+++ b/lib/profile/config.rb
@@ -11,7 +11,7 @@ module Profile
 
       def data
         @data ||= TTY::Config.new.tap do |cfg|
-          cfg.append_path(File.join(root, 'etc'))
+          cfg.append_path(config_path)
           begin
             cfg.read
           rescue TTY::Config::ReadError
@@ -71,13 +71,16 @@ module Profile
       end
 
       def set_permission
-        file_path = File.join(root, 'etc', data.filename + data.extname)
-        File.chmod(0600, file_path)
+        File.chmod(0600, File.join(config_path, data.filename + data.extname))
         puts "permission set"
       end
 
       def root
         @root ||= File.expand_path(File.join(__dir__, '..', '..'))
+      end
+
+      def config_path
+        @config_path = File.join(root, 'etc')
       end
 
       private

--- a/lib/profile/config.rb
+++ b/lib/profile/config.rb
@@ -72,7 +72,6 @@ module Profile
 
       def set_permission
         File.chmod(0600, File.join(config_path, data.filename + data.extname))
-        puts "permission set"
       end
 
       def root

--- a/lib/profile/config.rb
+++ b/lib/profile/config.rb
@@ -70,6 +70,12 @@ module Profile
         data.write(force: true)
       end
 
+      def set_permission
+        file_path = File.join(root, 'etc', data.filename + data.extname)
+        File.chmod(0600, file_path)
+        puts "permission set"
+      end
+
       def root
         @root ||= File.expand_path(File.join(__dir__, '..', '..'))
       end


### PR DESCRIPTION
# Overview

This PR adds a `Config.set_permission` method and calls this method in `configure.save_answers` right after the file is created and written to add the permission to the profile configuration file. It changes the default permission 644 to 600 so that only the owner of this configuration file can read or write it.

## Other changes

- a `Config.config_path` method is added to decouple the path of the `TTY::Config` instance in the previous `Config.data` method. In this case, if this path needs to be modified in the futured, it can be updated within `Config.config_path` without affecting the `Config.data` and `Config.set_permission` methods.