### PR TITLE
Properly exclude self when comparing identity conflicts

### DIFF
--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -34,7 +34,7 @@ module Profile
           names.append(expand_brackets(str))
         end
 
-        names.flatten!
+        names.flatten!.uniq!
 
         # If using hunter, check to see if node actually exists
         check_nodes_exist(names) if @hunter


### PR DESCRIPTION
This PR updates the conflict resolution logic in `apply` to properly exclude from the checks:
- the temporary node object created for application
- the potentially already existing node

This change fixes the bug where trying to apply to a failed node with the same identity (that conflicts with itself) would fail. Now, using the `--force` option lets the user try again.