### PR TITLE
Fix Nil Error When Trying to Remove an Applied Node with Outdated Identity

### DIFF
--- a/lib/profile/commands/remove.rb
+++ b/lib/profile/commands/remove.rb
@@ -167,7 +167,7 @@ module Profile
       end
 
       def check_nodes_removable(nodes)
-        not_removable = nodes.select { |node| !node.fetch_identity.removable? }
+        not_removable = nodes.select { |node| !node.fetch_identity&.removable? }
         if not_removable.any?
           out = <<~OUT.chomp
           The following nodes have an identity that doesn't currently support the `profile remove` command:


### PR DESCRIPTION
# Overview

When removing an applied node with an outdated identity that does not exist in the current cluster type, an error will occur since the identity cannot be correctly identified. Now this kind of nodes will be treated as non-removable nodes and give users an appropriate prompt when trying to remove them.