### PR TITLE
Stop querying Hunter in the queue monitor process

### DIFF
--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -266,7 +266,7 @@ module Profile
       def existing_nodes(names)
         existing = [].tap do |e|
           names.each do |name|
-            node = Node.find(name, include_hunter: @hunter)
+            node = Node.find(name, reload: true)
             e << node if node&.identity
           end
         end

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -75,7 +75,7 @@ module Profile
         existing = Node.all(reload: true)
 
         # Construct new node objects
-        new_nodes = Node.generate(names, identity.name, use_hunter: @hunter)
+        new_nodes = Node.generate(names, identity.name, include_hunter: @hunter)
 
         # Check for identity clashes
         total = existing + new_nodes

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -75,7 +75,7 @@ module Profile
         existing = Node.all(reload: true)
 
         # Construct new node objects
-        new_nodes = Node.generate(names, identity.name, include_hunter: @hunter)
+        new_nodes = Node.generate(names, identity.name, include_hunter: @hunter, reload: true)
 
         # Check for identity clashes
         total = existing + new_nodes
@@ -310,7 +310,7 @@ module Profile
       end
 
       def check_nodes_exist(names)
-        not_found = names.select { |n| !Node.find(n, include_hunter: true) }
+        not_found = names.select { |n| !Node.find(n, include_hunter: true, reload: true) }
         if not_found.any?
           out = <<~OUT.chomp
           The following nodes were not found in Profile or Hunter:

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -277,7 +277,7 @@ module Profile
           end
           a.concat(hunter_nodes)
         end
-      end.sort_by { |n| [n.hunter_label || n.hostname ] }
+      end.sort_by(&:name)
     end
   end
 end

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -40,20 +40,20 @@ module Profile
       end
     end
 
-    def self.generate(names, identity, use_hunter: false)
+    def self.generate(names, identity, include_hunter: false)
       names.map do |name|
         hostname =
-          case use_hunter
+          case include_hunter
           when true
-            Node.find(name, include_hunter: true).hostname
+            Node.find(name, include_hunter: include_hunter).hostname
           when false
             name
           end
 
         ip =
-          case use_hunter
+          case include_hunter
           when true
-            Node.find(name, include_hunter: true).ip
+            Node.find(name, include_hunter: include_hunter).ip
           when false
             nil
           end

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -40,29 +40,23 @@ module Profile
       end
     end
 
-    def self.generate(names, identity, include_hunter: false)
+    def self.generate(names, identity, include_hunter: false, reload: false)
       names.map do |name|
-        hostname =
+        hostname, ip, hunter_label =
           case include_hunter
           when true
-            Node.find(name, include_hunter: include_hunter).hostname
-          when false
-            name
-          end
+            existing = Node.find(name, include_hunter: include_hunter, reload: reload)
 
-        ip =
-          case include_hunter
-          when true
-            Node.find(name, include_hunter: include_hunter).ip
-          when false
-            nil
+            [existing&.hostname, existing&.ip, existing&.hunter_label]
+          else
+            [name, nil, nil]
           end
 
         Node.new(
           hostname: hostname,
           name: name,
           identity: identity,
-          hunter_label: Node.find(name, include_hunter: true)&.hunter_label,
+          hunter_label: hunter_label,
           ip: ip
         )
       end

--- a/lib/profile/queue_manager.rb
+++ b/lib/profile/queue_manager.rb
@@ -84,7 +84,7 @@ module Profile
 
       def queued_nodes
         Queue.index.map do |k,v|
-          Node.generate([k], v[:identity], use_hunter: Config.use_hunter?)
+          Node.generate([k], v[:identity])
         end.reduce([], &:+)
       end
 
@@ -100,8 +100,7 @@ module Profile
 
             temp_nodes = Node.generate(
               names,
-              group[:identity],
-              use_hunter: Config.use_hunter?
+              group[:identity]
             )
 
             to_apply = temp_nodes.select do |n|


### PR DESCRIPTION
This PR updates the queue monitor to stop using the `use_hunter` option when running `Node.generate`. It was executing Hunter commands excessively, causing delay, and it was raising errors when the nodes being generated didn't  exist in Hunter, which they didn't because the queue wasn't reloading the nodes every time. For example:
- `cnode01` is given the identity `compute`, and is added to the queue
  - at this point, the queue process starts, and is aware of the Hunter node `cnode01` only
- `cnode02` is given the identity `compute`, and is added to the queue
- `login1` is given the identity `login`, and begins applying
- when `login1` is done, the queue process attempts to resubmit the two nodes
- the `Node.generate` call tries to fetch Hunter data for both `cnode01` and `cnode01`
- an error is raised because the Hunter nodes haven't been reloaded since `cnode01` was submitted to, so it believes that `cnode02` doesn't exist, and an error is raised


This is indicative of a wider instability with regards to how we `find` nodes from Profile/Hunter, something that could have been addressed with the implementation of the queue system. For now, this fixes our problem.

A minor change has also been included to sort nodes returned from `fetch_all` by their `name` attribute, instead two of the three attributes that `name` is set from when a node is initialised.