### PR TITLE
Reload nodes in a persistent manner

### DIFF
--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -72,7 +72,7 @@ module Profile
         cmds = identity.commands
 
         # Fetch existing nodes
-        existing = Node.all(reload: true)
+        existing = Node.all
 
         # Construct new node objects
         new_nodes = Node.generate(names, identity.name, include_hunter: @hunter, reload: true)
@@ -266,7 +266,7 @@ module Profile
       def existing_nodes(names)
         existing = [].tap do |e|
           names.each do |name|
-            node = Node.find(name, reload: true)
+            node = Node.find(name)
             e << node if node&.identity
           end
         end
@@ -310,7 +310,7 @@ module Profile
       end
 
       def check_nodes_exist(names)
-        not_found = names.select { |n| !Node.find(n, include_hunter: true, reload: true) }
+        not_found = names.select { |n| !Node.find(n, include_hunter: true) }
         if not_found.any?
           out = <<~OUT.chomp
           The following nodes were not found in Profile or Hunter:

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -36,6 +36,9 @@ module Profile
 
         names.flatten!.uniq!
 
+        # Reload all nodes
+        Node.all(reload: true, include_hunter: @hunter)
+
         # If using hunter, check to see if node actually exists
         check_nodes_exist(names) if @hunter
 
@@ -72,10 +75,10 @@ module Profile
         cmds = identity.commands
 
         # Fetch existing nodes
-        existing = Node.all
+        existing = Node.all(include_hunter: @hunter, reload: true)
 
         # Construct new node objects
-        new_nodes = Node.generate(names, identity.name, include_hunter: @hunter, reload: true)
+        new_nodes = Node.generate(names, identity.name, include_hunter: @hunter)
 
         # Check for identity clashes
         total = existing + new_nodes

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -75,7 +75,7 @@ module Profile
         cmds = identity.commands
 
         # Fetch existing nodes
-        existing = Node.all(include_hunter: @hunter, reload: true)
+        existing = Node.all(include_hunter: @hunter)
 
         # Construct new node objects
         new_nodes = Node.generate(names, identity.name, include_hunter: @hunter)

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -10,11 +10,9 @@ require_relative './queue_manager'
 module Profile
   class Node
     def self.all(include_hunter: false, reload: false)
-      if reload
-        return fetch_all(include_hunter: include_hunter)
-      end
+      @all = nil if reload
 
-      @all_nodes ||= fetch_all(include_hunter: include_hunter)
+      @all ||= fetch_all(include_hunter: include_hunter)
     end
 
     def self.find(name=nil, include_hunter: false, reload: false)

--- a/lib/profile/queue_manager.rb
+++ b/lib/profile/queue_manager.rb
@@ -94,6 +94,9 @@ module Profile
         until Queue.index.empty?
           sleep(5)
 
+          # Reload node list
+          Node.all(reload: true)
+
           grouped = Queue.index.group_by { |k,v| v }
           grouped.each do |group, nodes|
             names = nodes.map(&:first)
@@ -104,7 +107,7 @@ module Profile
             )
 
             to_apply = temp_nodes.select do |n|
-              saved_nodes = Node.all(reload: true).select { |n| n.status == 'complete' }
+              saved_nodes = Node.all.select { |n| n.status == 'complete' }
               total = (saved_nodes + queued_nodes).reject do |q|
                 q.name == n.name
               end


### PR DESCRIPTION
This PR updates the behaviour of the `reload` option on `Node::all`. Previously, using the `reload` option would return an updated copy of `Node:all`, whereas not using it would return the set of nodes loaded when `Node::all` was first run.

The above behaviour meant that we had to use the `reload` option every time we wanted anything that didn't exist when Profile was executed. Now that we have a queuing system, which relies on a background process of Profile, we need a better way of reloading nodes, such that we don't have to fork out to Flight Hunter numerous times per execution.

The new implementation overwrites the saved copy of `Node::all` when the reload option is included, so it can be reused later. Correspondingly, most instances of `reload` have been removed.