### PR TITLE
Improve node status evaluation

### DIFF
--- a/lib/profile/commands/list.rb
+++ b/lib/profile/commands/list.rb
@@ -7,11 +7,12 @@ module Profile
     class List < Command
       def run
         hunter = Config.use_hunter?
-        raise "No nodes to display" if !Node.all(include_hunter: hunter).any?
+        nodes = Node.all(include_hunter: hunter)
+        raise "No nodes to display" unless nodes.any?
 
         t = Table.new
         t.headers('Node', 'Identity', 'Status')
-        Node.all.each do |node|
+        nodes.each do |node|
           identity = case QueueManager.contains?(node.name)
                      when true
                        QueueManager.identity(node.name)

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -141,7 +141,9 @@ module Profile
           'applying'
         end
       elsif persisted?
-        if exit_status > 0
+        if exit_status.nil?
+          'unknown'
+        elsif exit_status > 0
           'failed'
         elsif exit_status == 0
           'complete'


### PR DESCRIPTION
This PR updates the logic for evaluating the current status of a node. Since the method was implemented, more possible statuses have become available. Subsequent changes to the method have obfuscated the logic a bit. It's difficult to tell which status a node will have just by looking at it, and it was easy for erroneous results to be returned.

The method has been updated to have a clearer flow to it, as well as covering every situation.

- We are no longer running the `ps -e` system command to check if a node is in-progress; it has been replaced with `Process.kill(0)`
- The `unknown` status has been added for when a node is saved with a deployment PID, but the PID doesn't exist in the system.