### PR TITLE
Allow multiple default_smart commands per prefill

### DIFF
--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -75,7 +75,7 @@ module Profile
         if question.default_smart && prefill.nil?
           prefill ||= best_command_output(command_list: question.default_smart,
                                           log: smart_log,
-                                          regex: question.validation.has_key?(:format) ? question.validation.format : nil)
+                                          regex: question.validation&.has_key?(:format) ? question.validation.format : nil)
         end
         prefill ||= question.default || ""
       end


### PR DESCRIPTION
This PR allows multiple commands to be used concurrently to determine each `default_smart`. Previously, only one command could be used for each of the smart defaults, meaning that values which can be generated in multiple ways would all need to be run sequentially within the 5s time limit. With this new change the `default_smart` field is now an array of commands - each command will be run in parallel with its own 5s timeout limit, and the highest priority command which completes successfully will be used.  Additionally, `configure` won't wait for lower-priority commands to finish running unless it needs to.

The priority of each command is the same as its position in the list, the first command in the list has the highest priority.