### PR TITLE
Support Force Apply for Queued Node

### DIFF
--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -128,7 +128,8 @@ module Profile
 
         unless to_queue.empty?
           options = {
-            'remove_on_shutdown' => @remove_on_shutdown
+            'remove_on_shutdown' => @remove_on_shutdown,
+            'force' => @options.force
           }
 
           to_queue.each do |node|

--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -21,7 +21,7 @@ module Profile
         # ARGS:
         # [ names, identity ]
         # OPTS:
-        # [ force ]
+        # [ wait, force, remove_on_shutdown ]
         @hunter = Config.use_hunter?
         @remove_on_shutdown = @options.remove_on_shutdown || Config.remove_on_shutdown
 


### PR DESCRIPTION
# Overview
 
This PR supports the `force` option for the queued nodes.

# Major Changes

- add the `force` as a field of the `options` attribute for queued node.

# Minor Changes

- Update comment.

# Testing

1. Launch 2 Flight Solo instances.
2. Take one of the instances as the main instance, overwrite the integrated Flight Profile located at /opt/flight/opt/profile with the content of this branch.
3. Use Flight Hunter to hunt and parse both instances as `main` and `vice` nodes.
4. Edit the `/root/.ssh/authorized_keys` file of the `vice` node with the key of the `main` node.
5. run `flight profile configure` on `main` with the cluster type set to `Openflight Jupyter Standalone`.
6. run `flight profile apply main all-in-one` and wait until `flight profile list` shows the apply process has completed.
7. run `flight profile configure --reset-type` with the cluster type resset to `Openflight Slurm Multinode`. For the followed questions, use the ip address of the `vice` node.
8. run `flight profile apply main compute --force`. The `main` node should be added to the queue.
9. run `flight profile apply vice login`. The apply process should start. After the `vice` node is succesfully applied, the apply process of the `main` node should also start and eventually complete.