### PR TITLE
Abort `prepare` scripts when sub-commands fail

### DIFF
--- a/lib/profile/type.rb
+++ b/lib/profile/type.rb
@@ -99,7 +99,7 @@ module Profile
       log_name = "#{Config.log_dir}/#{id}-#{Time.now.to_i}.log"
 
       Open3.popen2e(
-        prepare_command,
+        "bash -e #{prepare_command}",
         chdir: run_env
       )  do |stdin, stdout_stderr, wait_thr|
         Thread.new do


### PR DESCRIPTION
This small PR causes each type's `prepare` script to exit whenever an error occurs in the script. This allows Profile to properly detect that the preparation has failed. Previously the scripts would only exit with error codes if the last command in the file exited with an error.