### PR TITLE
Display task runtimes in `view` output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gem 'flight-subprocess', github: 'openflighthpc/flight-subprocess', tag: '0.1.4'
 gem 'commander-openflighthpc', '~> 2.2.0'
+gem 'rubocop', group: 'development', require: false
 gem 'tty-table'
 gem 'tty-prompt'
 gem 'tty-config'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
     bcrypt_pbkdf (1.1.0)
     commander-openflighthpc (2.2.0)
       highline (> 1.7.2)
@@ -26,13 +27,35 @@ GEM
     curses (1.4.4)
     ed25519 (1.3.0)
     highline (2.0.3)
+    json (2.7.1)
     jwt (2.7.1)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
     net-ssh (6.1.0)
     paint (2.1.1)
+    parallel (1.24.0)
+    parser (3.3.0.2)
+      ast (~> 2.4.1)
+      racc
     pastel (0.8.0)
       tty-color (~> 0.5)
+    racc (1.7.3)
+    rainbow (3.1.1)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
+    rubocop (1.42.0)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.1.2.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.24.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
     shash (0.0.7)
     slop (4.9.2)
     strings (0.2.1)
@@ -68,6 +91,7 @@ DEPENDENCIES
   flight-subprocess!
   jwt
   net-sftp
+  rubocop
   shash (~> 0.0.7)
   tty-config
   tty-prompt

--- a/lib/profile/commands/view.rb
+++ b/lib/profile/commands/view.rb
@@ -110,7 +110,7 @@ module Profile
       class Task
         SUCCESS_STATUSES = %w[ok changed rescued].freeze
         FAIL_STATUSES = %w[failed fatal unreachable].freeze
-        SKIP_STATUSES = %w[skipped ignored ok].freeze
+        SKIP_STATUSES = %w[skipped ignored].freeze
         DONE_STATUSES = SUCCESS_STATUSES + FAIL_STATUSES + SKIP_STATUSES
 
         def initialize(name, steps)
@@ -183,6 +183,8 @@ module Profile
             task.steps.each { |s| str += s['raw'] }
           else
             role = task.role
+            next if role == 'None'
+
             new_role = !roles.key?(role)
             roles[role] += 1 unless task.skipped?
             str += "#{role}\n" if new_role && (roles[role]).positive?
@@ -206,7 +208,7 @@ module Profile
           next unless secs.positive?
 
           secs, number = secs.divmod(count)
-          "#{number.to_i} #{name}" unless number.to_i.zero?
+          "#{number.to_i}#{name}" unless number.to_i.zero?
         end.compact.reverse.join(', ')
       end
     end

--- a/lib/profile/commands/view.rb
+++ b/lib/profile/commands/view.rb
@@ -188,19 +188,26 @@ module Profile
             str += "#{role}\n" if new_role && (roles[role]).positive?
 
             if task.success?
-              str += "   \u2705 #{task.name} (done in #{format_time(task.runtime)}s)\n"
+              str += "   \u2705 #{task.name} (done in #{format_time(task.runtime)})\n"
             elsif task.failure?
-              str += "   \u274c #{task.name} (done in #{format_time(task.runtime)}s)\n"
+              str += "   \u274c #{task.name} (done in #{format_time(task.runtime)})\n"
             elsif task.in_progress?
-              str += "   \u231b #{task.name} (#{task.runtime} seconds elapsed)\n"
+              str += "   \u231b #{task.name} (#{format_time(task.runtime)} elapsed)\n"
             end
           end
         end
         str
       end
 
-      def format_time(time)
-        time < 1 ? '<1' : time
+      def format_time(secs)
+        return '<1s' if secs < 1
+
+        [[60, :s], [60, :m], [24, :h], [Float::INFINITY, :d]].map do |count, name|
+          next unless secs.positive?
+
+          secs, number = secs.divmod(count)
+          "#{number.to_i} #{name}" unless number.to_i.zero?
+        end.compact.reverse.join(', ')
       end
     end
   end

--- a/lib/profile/commands/view.rb
+++ b/lib/profile/commands/view.rb
@@ -180,14 +180,18 @@ module Profile
           if @options.raw
             task.steps.each { |s| str += s['raw'] }
           elsif task.success?
-            str += "   \u2705 #{task.name} (done in #{task.runtime}s)\n"
+            str += "   \u2705 #{task.name} (done in #{format_time(task.runtime)}s)\n"
           elsif task.failure?
-            str += "   \u274c #{task.name} (done in #{task.runtime}s)\n"
+            str += "   \u274c #{task.name} (done in #{format_time(task.runtime)}s)\n"
           elsif task.in_progress?
             str += "   \u231b #{task.name} (#{task.runtime} seconds elapsed)\n"
           end
         end
         str
+      end
+
+      def format_time(time)
+        time < 1 ? '<1' : time
       end
     end
   end

--- a/lib/profile/commands/view.rb
+++ b/lib/profile/commands/view.rb
@@ -1,4 +1,5 @@
 require 'curses'
+require 'time'
 
 require_relative '../command'
 
@@ -123,7 +124,6 @@ HEREDOC
       end
 
       def display_task_status(command)
-        new_role = nil
         roles = Hash.new(0)
         str = ""
         command.split("\n").each_with_index do |line, idx|
@@ -138,6 +138,7 @@ HEREDOC
 
             next if parts['task_role'] == 'None'
 
+            time = Time.parse(parts['time'])
             role = parts['task_role']
             new_role = !roles.key?(role)
             roles[role] += 1 unless parts['category'] == 'SKIPPED'

--- a/opt/ansible_callbacks/log_plays_v2.py
+++ b/opt/ansible_callbacks/log_plays_v2.py
@@ -110,6 +110,15 @@ class CallbackModule(CallbackBase):
         with open(path, "ab") as fd:
             fd.write(msg)
 
+
+    def v2_runner_on_start(self, host, task):
+        path = os.path.join(self.log_folder, host.get_name())
+        now = time.strftime(self.TIME_FORMAT, time.localtime())
+        print(dir(host))
+        with open(path, "a") as fd:
+            msg = now + ' - ' + self.playbook + ' - ' + task._role.get_name() + ' - '+ task.name + ' - ' + task.action + ' - STARTED\n'
+            fd.write(msg)
+
     def v2_runner_on_failed(self, result, ignore_errors=False):
         self.log(result, 'FAILED')
 


### PR DESCRIPTION
# Overview

This PR updates the output of `view` to include runtimes for each Ansible task, as well as a live-updating timer for the current task.

Previously, a task was only included in the output once it had _finished_. This made it very difficult to know which task the process was currently on. Bad user experience ensures. Also, if the process hangs or breaks, knowing which task it is stuck on is important debug information for developers/admininstrators.

# Work done

- The custom `log_plays_v2` Ansible callback has been updated to log the start of each task as well as the end of each task. We use the timestamp from this 'STARTED' line to calculate the runtime of the task.
- The `view` command has been streamlined to separate the logfile into tasks, and then:
  - If the task is running, show the task name with an hourglass icon and the elapsed time (2 decimal places because we're comparing the Ansible timestamp (no milliseconds) with the current system time)
  - If the task is finished, show the task name with the runtime of the task (0 decimal places because we're comparing two Ansible timestamps)
- The `rubocop` linter has been run on the `view` command file, resulting in some miscellaneous formatting updates, heredoc stylistic changes, and constant freezing.

# Future enhancements

- Some may find the time data to be a little verbose. Hiding it behind a command-line option may be preferable.
- Extra time data could be included to show the total runtime per command, as well as per task (perhaps even the runtime for the entire process).