### PR TITLE
Capture Apply/Remove stdout & stderr into a Log File

### DIFF
--- a/lib/profile/process_spawner.rb
+++ b/lib/profile/process_spawner.rb
@@ -33,8 +33,8 @@ module Profile
               process_log = File.open(process_path, 'a')
               exit_status = nil
               Open3.popen3(env, command['command']) do |_stdin, stdout, stderr, wait_thr|
-                process_log.write(stdout)
-                process_log.write(stderr)
+                process_log.write(stdout.read)
+                process_log.write(stderr.read)
                 exit_status = wait_thr.value.exitstatus
               end
               process_log.close

--- a/lib/profile/process_spawner.rb
+++ b/lib/profile/process_spawner.rb
@@ -28,7 +28,7 @@ module Profile
               end
 
               process_path = File.join(Config.log_dir, "process-#{Time.now.to_i}.log")
-              process_log = File.open(process_path, 'w')
+              process_log = File.open(process_path, 'a')
               sub_pid = Process.spawn(
                 env,
                 command['command'],

--- a/lib/profile/process_spawner.rb
+++ b/lib/profile/process_spawner.rb
@@ -27,12 +27,15 @@ module Profile
                 )
               end
 
+              process_path = File.join(Config.log_dir, "process-#{Time.now.to_i}.log")
+              process_log = File.open(process_path, 'w')
               sub_pid = Process.spawn(
                 env,
-                command['command']
+                command['command'],
+                [:out, :err] => process_path
               )
-
               Process.wait(sub_pid)
+              process_log.close
               exit_status = $?.exitstatus
 
               if exit_status != 0 || idx == commands.size - 1


### PR DESCRIPTION
# Overview

This PR solves the issue that the error occurred outside the ansible commands of the subprocess won't be logged into any files. Now these missing error messages will be written to a file named `process-<timestamp>.log` under the log directory.

# Main Changes

- The `process_spawner.rb` is modified to redirect the `stdout` and `stderr` of the subprocesses to log files.

# Testing

1. Launch a new Flight Solo instance and run the following commands:
   ```
   git clone https://github.com/openflighthpc/flight-profile.git && cd flight-profile
   git checkout dev/capture-process-stdout-stderr
   unalias cp
   cp -rf ./* /opt/flight/opt/profile
   flight hunter hunt --include-self
   flight hunter parse # parse the self node as "allinone"
   flight profile configure # configure a jupyter standalone cluster
   ```
2. Modify the commands YAML file:
   ```
   vim /opt/flight/usr/lib/profile/types/openflight-jupyter-standalone/identities/allinone/commands.yaml
   ```
   Overwrite the file with the following contents:
   ```
   # There is a "cd errerrerr &&" statement at the beginning of the command
   apply:
   - name: Apply All-in-One Profile
     command: "cd errerrerr && ansible-playbook -i $INVFILE --limit $NODE --extra-vars=\"cluster_name=$CLUSTERNAME default_username=$DEFAULT_USERNAME default_user_password=$DEFAULT_PASSWORD access_host=$ACCESS_HOST\" $RUN_ENV/openflight-jupyter-standalone/main.yml"
   ```
3. Run `flight profile apply allinone all-in-one`. It should eventually fail.
4. Run `ls /opt/flight/opt/profile/var/log`. There should be a `.log` file that its name started with "process"
5. `cat` the file and it should return `sh: line 1: cd: errerrerr: No such file or directory`.