### PR TITLE
Store a 'last known action' attribute for nodes

### DIFF
--- a/lib/profile/commands/apply.rb
+++ b/lib/profile/commands/apply.rb
@@ -255,12 +255,12 @@ module Profile
           # - the final command
           # We yield it in a block so that the rest of the `apply`
           # logic can continue asynchronously.
-          node_objs.update_all(deployment_pid: nil, exit_status: last_exit)
+          node_objs.update_all(deployment_pid: nil, exit_status: last_exit, last_action: nil)
 
           node_objs.each(&:install_remove_hook) if @remove_on_shutdown && last_exit.zero?
         end
 
-        node_objs.update_all(deployment_pid: pid.to_i)
+        node_objs.update_all(deployment_pid: pid.to_i, last_action: 'apply')
 
         unless @options.wait
           puts 'The application process has begun. Refer to `flight profile list` '\

--- a/lib/profile/commands/remove.rb
+++ b/lib/profile/commands/remove.rb
@@ -114,7 +114,7 @@ module Profile
             env: env,
             log_files: nodes.map(&:log_filepath)
           ) do |last_exit|
-            node_objs.update_all(deployment_pid: nil, exit_status: last_exit)
+            node_objs.update_all(deployment_pid: nil, exit_status: last_exit, last_action: nil)
 
             node_objs.destroy_all if last_exit == 0
             if last_exit == 0 && @hunter && @remove_hunter_entry
@@ -122,7 +122,7 @@ module Profile
             end
           end
 
-          node_objs.update_all(deployment_pid: pid.to_i)
+          node_objs.update_all(deployment_pid: pid.to_i, last_action: 'remove')
         end
 
 

--- a/lib/profile/node.rb
+++ b/lib/profile/node.rb
@@ -78,7 +78,8 @@ module Profile
         'deployment_pid' => deployment_pid,
         'exit_status' => exit_status,
         'ip' => ip,
-        'groups' => groups
+        'groups' => groups,
+        'last_action' => last_action
       }
     end
 
@@ -263,9 +264,9 @@ module Profile
     end
 
     attr_reader :name
-    attr_accessor :hostname, :identity, :deployment_pid, :exit_status, :hunter_label, :ip, :groups
+    attr_accessor :hostname, :identity, :deployment_pid, :exit_status, :hunter_label, :ip, :groups, :last_action
 
-    def initialize(hostname:, identity: nil, deployment_pid: nil, exit_status: nil, hunter_label: nil, name: nil, ip: nil, groups: [])
+    def initialize(hostname:, identity: nil, deployment_pid: nil, exit_status: nil, hunter_label: nil, name: nil, ip: nil, groups: [], last_action: nil)
       @hostname = hostname
       @identity = identity
       @deployment_pid = deployment_pid
@@ -274,6 +275,7 @@ module Profile
       @name = name || hunter_label || hostname
       @ip = ip
       @groups = groups
+      @last_action = last_action
     end
 
     private


### PR DESCRIPTION
# Summary

This PR adds a single attribute to the `Node` class, `last_action`, to track what the node was last seen doing. It is part of work being made to [Flight Starter](https://github.com/openflighthpc/flight-starter/) to include stats in the login banner for how many nodes are in your cluster, plus how many are currently undergoing an `apply` process.

The `last_action` attribute is written when a process is started, and nixed when a process ends; it is treated the same way as the `deployment_pid` attribute. It is designed to be used as an API for tools that don't want to go through the usual Flight environment workflow. Something like a login banner doesn't want to wait more than a second to get the data it needs, which is what it would be doing if it ran `flight profile list` and waited for the data to come through. Flight Profile itself does not currently use the `last_action` attribute for anything meaningful.

# Future enhancements

- The introduction of the `last_action` attribute may help us simplify our own process for working out a node's current status. If we are storing an (assumedly) tamper-safe record of the last thing to be run on the node, we no longer have to search for a logfile for that node and extract the action from there.