### PR TITLE
Fix `prepare` command never failing properly

### DIFF
--- a/lib/profile/commands/prepare.rb
+++ b/lib/profile/commands/prepare.rb
@@ -19,7 +19,7 @@ module Profile
 
         raise "Cluster type is already prepared." if cluster_type.prepared?
         puts "Preparing '#{cluster_type.name}' cluster type..."
-        if cluster_type.prepare
+        if cluster_type.prepare.success?
           puts "'#{cluster_type.name}' prepared."
           cluster_type.verify
         else


### PR DESCRIPTION
This small PR fixes the `prepare` command not properly assessing its exit status.