### PR TITLE
Properly Handle the --accept-defaults Option

### DIFF
--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -27,6 +27,7 @@ module Profile
 
       def use_cli_answers
         cli_answers.tap do |a|
+          given = a&.keys || []
           all_questions = cluster_type.recursive_questions
           if @options.accept_defaults
             generate_prefills(cluster_type.questions)
@@ -34,13 +35,11 @@ module Profile
               a[question.id] ||= @prefills[question.id] unless @prefills[question.id].nil?
             end
           end
-          given = a&.keys || []
           missing = missing_answers(a)
           raise "The following questions were not answered by the JSON data: #{missing.join(", ")}" unless missing.empty?
 
           required = required_answers(a)
           invalid = given - required
-          invalid -= all_questions.map(&:id) if @options.accept_defaults
           raise "The following given answers are not recognised by the cluster type: #{invalid.join(", ")}" unless invalid.empty?
         end
       end

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -64,6 +64,7 @@ module Profile
             next unless parent_answer.nil? || parent_answer == q.where
             ra << q.id
             ra.concat(required_answers(answers), q.questions, answers[q.id]) if q.questions
+          end
         end
       end
 

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -28,7 +28,7 @@ module Profile
       def use_cli_answers
         cli_answers.tap do |a|
           if @options.accept_defaults
-            generate_prefills(question)
+            generate_prefills(cluster_type.questions)
             cluster_type.recursive_questions.each do |question|
               a[question.id] ||= @prefills[question.id] unless @prefills[question.id].nil?
             end

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -27,7 +27,7 @@ module Profile
 
       def use_cli_answers
         cli_answers.tap do |as|
-          given = a&.keys || []
+          given = as&.keys || []
           all_questions = cluster_type.recursive_questions
           invalid_boolean_answers = all_questions.select { |q| q.type == 'boolean' && !as[q.id].is_a?(TrueClass) && !as[q.id].is_a?(FalseClass) && !as[q.id].nil? }.map(&:id)
           raise "The following questions requires boolean answers: #{invalid_boolean_answers.join(", ")}" unless invalid_boolean_answers.empty?

--- a/lib/profile/commands/configure.rb
+++ b/lib/profile/commands/configure.rb
@@ -63,7 +63,7 @@ module Profile
           questions.each do |q|
             next unless parent_answer.nil? || parent_answer == q.where
             ra << q.id
-            ra.concat(required_answers(answers), q.questions, answers[q.id]) if q.questions
+            ra.concat(required_answers(answers, q.questions, answers[q.id])) if q.questions
           end
         end
       end


### PR DESCRIPTION
# Overview

With the update for the conditional configure question support, a bug was introduced, which broke the behavior of the `--accept-defaults` option when the inline configuration answers are enabled by `--answer`. This PR aims to fix the issue.

# Expected Testing Result

The following expectations are based on the scenario that the user is configuring an Openflight Slurm Multinode cluster with the `--answer` inline configuration option:

- If `--accept-defaults` is **_not_** enabled and incomplete inline answers are given, the program will raise an error telling the missing answers.
- If `--accept-defaults` is **_not_** enabled, inline answers are fully given, `ipa_use` is set to `false`, `ipa_domain` is set to `www.example.com`, the program will raise an error treating the `ipa_domain` as an unrecognized field.
- If `--accept-defaults` is **_not_** enabled and inline answers are fully given with extra random answers, the program will raise an error telling the unrecognized redundant answers.

 

- If `--accept-defaults` is enabled, inline answers are partially given, `ipa_use` is set to `false`, `ipa_domain` is set to `www.example.com`, the program will raise an error treating the `ipa_domain` as an unrecognized field.
- If `--accept-defaults` is enabled, inline answers are partially given, `ipa_use` is set to `false`, and `ipa_domain` is **_not_** explicitly provided (it has a default answer though), the program should not raise errors about unrecognized `ipa_domain`.
- If `--accept-defaults` is enabled and inline answers are partially given with extra random answers, the program will raise an error telling the unrecognized redundant answers.
