### PR TITLE
Ensure shutdown run before nfs-server stops

### DIFF
--- a/opt/profile-shutdown.service
+++ b/opt/profile-shutdown.service
@@ -3,7 +3,7 @@ Description="cURL headnode with Flight Profile remove request"
 DefaultDependencies=no
 Requires=network.target
 Before=shutdown.target
-After=sshd.service flight-slurmd.service
+After=sshd.service flight-slurmd.service nfs-server.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
With the introduction in openflight-slurm-multinode cluster type there will be the possibility for anything to be an NFS server. In the event that something sharing NFS is shut down then, to prevent other systems from locking up, the remove process will need to do a umount on all clients.

This change adds the nfs-server service as a dependency for shutdown, this works even on systems that aren't NFS servers as it will simply be ignored. (Tested by adding gibberish non-existent service to the shutdown script and observing that it is ignored)

References: https://github.com/openflighthpc/openflight-slurm-multinode/pull/7 https://github.com/openflighthpc/flight-profile-types/pull/27